### PR TITLE
Fix deprecations

### DIFF
--- a/src/Panes/FontsPane.vala
+++ b/src/Panes/FontsPane.vala
@@ -54,10 +54,10 @@ namespace ElementaryTweaks {
         }
 
         protected override void init_data () {
-            default_font.font_name = InterfaceSettings.get_default ().font_name;
-            document_font.font_name = InterfaceSettings.get_default ().document_font_name;
-            mono_font.font_name = InterfaceSettings.get_default ().monospace_font_name;
-            titlebar_font.font_name = WindowSettings.get_default ().titlebar_font;
+            default_font.font = InterfaceSettings.get_default ().font_name;
+            document_font.font = InterfaceSettings.get_default ().document_font_name;
+            mono_font.font = InterfaceSettings.get_default ().monospace_font_name;
+            titlebar_font.font = WindowSettings.get_default ().titlebar_font;
         }
 
         private void connect_signals () {

--- a/src/Widgets/Categories.vala
+++ b/src/Widgets/Categories.vala
@@ -146,7 +146,7 @@ namespace ElementaryTweaks {
 
             protected void connect_font_button (Gtk.FontButton button, SetValue<string> set_func) {
                 button.font_set.connect (() => {
-                    set_func (button.get_font_name ());
+                    set_func (button.font);
                 });
             }
 


### PR DESCRIPTION
## Changes Summary

* Use `Gtk.FontButton.font` instead of `Gtk.FontButton.font_name` (deprecated since 3.22)
* Use `Gtk.FontButton.font` instead of `Gtk.FontButton.get_font_name` (deprecated since 3.22)
