### PR TITLE
Fix warnings when target dirs/keyfiles doesn't exist

### DIFF
--- a/src/Settings/GtkSettings.vala
+++ b/src/Settings/GtkSettings.vala
@@ -25,18 +25,17 @@ namespace PantheonTweaks {
         private GLib.KeyFile keyfile;
         private string path;
         private static GtkSettings? instance = null;
-        private bool keyfile_exists = false;
 
         /**
          * GTK should prefer the dark theme or not
          */
         public bool prefer_dark_theme {
             get {
-                if (keyfile_exists) {
-                    return (get_integer ("gtk-application-prefer-dark-theme") == 1);
-                } else {
+                if (!(File.new_for_path (path).query_exists ())) {
                     return false;
                 }
+
+                return (get_integer ("gtk-application-prefer-dark-theme") == 1);
             }
             set { set_integer ("gtk-application-prefer-dark-theme", value ? 1 : 0); }
         }
@@ -52,8 +51,6 @@ namespace PantheonTweaks {
             if (!(File.new_for_path (path).query_exists ())) {
                 return;
             }
-
-            keyfile_exists = true;
 
             try {
                 keyfile.load_from_file (path, 0);

--- a/src/Settings/GtkSettings.vala
+++ b/src/Settings/GtkSettings.vala
@@ -25,12 +25,19 @@ namespace PantheonTweaks {
         private GLib.KeyFile keyfile;
         private string path;
         private static GtkSettings? instance = null;
+        private bool keyfile_exists = false;
 
         /**
          * GTK should prefer the dark theme or not
          */
         public bool prefer_dark_theme {
-            get { return (get_integer ("gtk-application-prefer-dark-theme") == 1); }
+            get {
+                if (keyfile_exists) {
+                    return (get_integer ("gtk-application-prefer-dark-theme") == 1);
+                } else {
+                    return false;
+                }
+            }
             set { set_integer ("gtk-application-prefer-dark-theme", value ? 1 : 0); }
         }
 
@@ -40,8 +47,15 @@ namespace PantheonTweaks {
         public GtkSettings () {
             keyfile = new GLib.KeyFile ();
 
+            path = GLib.Environment.get_user_config_dir () + "/gtk-3.0/settings.ini";
+
+            if (!(File.new_for_path (path).query_exists ())) {
+                return;
+            }
+
+            keyfile_exists = true;
+
             try {
-                path = GLib.Environment.get_user_config_dir() + "/gtk-3.0/settings.ini";
                 keyfile.load_from_file (path, 0);
             }
             catch (Error e) {

--- a/src/Util.vala
+++ b/src/Util.vala
@@ -31,8 +31,13 @@ namespace PantheonTweaks {
                 Environment.get_home_dir () + "/.local/share/" + path + "/"};
 
             foreach (string dir in dirs) {
+                var file = File.new_for_path (dir);
+                if (!file.query_exists ()) {
+                    continue;
+                }
+
                 try {
-                    var enumerator = File.new_for_path (dir).enumerate_children (FileAttribute.STANDARD_NAME, 0);
+                    var enumerator = file.enumerate_children (FileAttribute.STANDARD_NAME, 0);
                     FileInfo file_info;
                     while ((file_info = enumerator.next_file ()) != null) {
                         var name = file_info.get_name ();
@@ -42,7 +47,9 @@ namespace PantheonTweaks {
                                 name != "Emacs" && name != "Default" && name != "default" && !themes.contains(name))
                             themes.add(name);
                     }
-                } catch (Error e) { /*warning (e.message);*/ }
+                } catch (Error e) {
+                    warning (e.message);
+                }
             }
 
             return themes;


### PR DESCRIPTION
We see the following errors if we have never change the dark style settings:

```
** (io.elementary.switchboard:21479): WARNING **: 11:31:30.143: GtkSettings.vala:48: Error loading GTK+ Keyfile settings.ini: No such file or directory

** (io.elementary.switchboard:21479): WARNING **: 11:31:30.143: GtkSettings.vala:69: Error getting GTK+ int setting: Key file does not have group “Settings”
```

This PR fixes these warnings shown when target dirs/keyfiles doesn't exist.

Also, don't crush errors―I guess someone commented out this `warning (e.message);` because they knew this shows unwanted error messages about missing files. However, this prevent us from debugging errors if some errors occur in `enumerate_children` method.
