### PR TITLE
Move the methods in Utils to more suitable files

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,8 +16,8 @@ subdir('po')
 
 plug_files = files(
     'src/Tweaks.vala',
-    'src/Util.vala',
     'src/Settings/GtkSettings.vala',
+    'src/Settings/ThemeSettings.vala',
     'src/Settings/XSettings.vala',
     'src/Panes/AudiencePane.vala',
     'src/Panes/AnimationsPane.vala',

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,6 +1,6 @@
 src/Tweaks.vala
-src/Util.vala
 src/Settings/GtkSettings.vala
+src/Settings/ThemeSettings.vala
 src/Settings/XSettings.vala
 src/Panes/AudiencePane.vala
 src/Panes/AnimationsPane.vala

--- a/src/Panes/AnimationsPane.vala
+++ b/src/Panes/AnimationsPane.vala
@@ -28,7 +28,7 @@ public class PantheonTweaks.Panes.AnimationsPane : Categories.Pane {
     }
 
     construct {
-        if (!Util.schema_exists (ANIMATIONS_SCHEMA)) {
+        if (!schema_exists (ANIMATIONS_SCHEMA)) {
             return;
         }
 

--- a/src/Panes/AppearancePane.vala
+++ b/src/Panes/AppearancePane.vala
@@ -42,7 +42,7 @@ public class PantheonTweaks.Panes.AppearancePane : Categories.Pane {
         var theme_label = new Granite.HeaderLabel (_("Theme Settings"));
 
         var gtk_label = new SummaryLabel (_("GTK+:"));
-        var gtk_map = Util.get_themes_map ("themes", "gtk-3.0");
+        var gtk_map = ThemeSettings.get_themes_map ("themes", "gtk-3.0");
         var gtk_combobox = new ComboBoxText (gtk_map);
 
         /// TRANSLATORS: The "%s" represents the path where custom themes are installed
@@ -51,7 +51,7 @@ public class PantheonTweaks.Panes.AppearancePane : Categories.Pane {
         ));
 
         var icon_label = new SummaryLabel (_("Icons:"));
-        var icon_map = Util.get_themes_map ("icons", "index.theme");
+        var icon_map = ThemeSettings.get_themes_map ("icons", "index.theme");
         var icon_combobox = new ComboBoxText (icon_map);
 
         /// TRANSLATORS: The "%s" represents the path where custom icons are installed
@@ -60,7 +60,7 @@ public class PantheonTweaks.Panes.AppearancePane : Categories.Pane {
         ));
 
         var cursor_label = new SummaryLabel (_("Cursor:"));
-        var cursor_map = Util.get_themes_map ("icons", "cursors");
+        var cursor_map = ThemeSettings.get_themes_map ("icons", "cursors");
         var cursor_combobox = new ComboBoxText (cursor_map);
 
         /// TRANSLATORS: The "%s" represents the path where custom cursors are installed

--- a/src/Panes/AudiencePane.vala
+++ b/src/Panes/AudiencePane.vala
@@ -26,11 +26,11 @@ public class PantheonTweaks.Panes.AudiencePane : Categories.Pane {
     }
 
     construct {
-        if (!(Util.schema_exists (VIDEOS_OLD_SCHEMA) || Util.schema_exists (VIDEOS_NEW_SCHEMA))) {
+        if (!(schema_exists (VIDEOS_OLD_SCHEMA) || schema_exists (VIDEOS_NEW_SCHEMA))) {
             return;
         }
 
-        var settings = new Settings ((Util.schema_exists (VIDEOS_NEW_SCHEMA)) ? VIDEOS_NEW_SCHEMA : VIDEOS_OLD_SCHEMA);
+        var settings = new Settings ((schema_exists (VIDEOS_NEW_SCHEMA)) ? VIDEOS_NEW_SCHEMA : VIDEOS_OLD_SCHEMA);
 
         var stay_on_top_label = new SummaryLabel (_("Stay on top while playing:"));
         var stay_on_top_switch = new Switch ();

--- a/src/Panes/FilesPane.vala
+++ b/src/Panes/FilesPane.vala
@@ -26,11 +26,11 @@ public class PantheonTweaks.Panes.FilesPane : Categories.Pane {
     }
 
     construct {
-        if (!(Util.schema_exists (FILES_OLD_SCHEMA) || Util.schema_exists (FILES_NEW_SCHEMA))) {
+        if (!(schema_exists (FILES_OLD_SCHEMA) || schema_exists (FILES_NEW_SCHEMA))) {
             return;
         }
 
-        var settings = new GLib.Settings ((Util.schema_exists (FILES_NEW_SCHEMA)) ? FILES_NEW_SCHEMA : FILES_OLD_SCHEMA);
+        var settings = new GLib.Settings ((schema_exists (FILES_NEW_SCHEMA)) ? FILES_NEW_SCHEMA : FILES_OLD_SCHEMA);
 
         var single_click_label = new SummaryLabel (_("Single click:"));
         var single_click_switch = new Switch ();

--- a/src/Panes/MiscPane.vala
+++ b/src/Panes/MiscPane.vala
@@ -28,7 +28,7 @@ public class PantheonTweaks.Panes.MiscPane : Categories.Pane {
     }
 
     construct {
-        if (!Util.schema_exists (SOUND_SCHEMA)) {
+        if (!schema_exists (SOUND_SCHEMA)) {
             return;
         }
 

--- a/src/Panes/TerminalPane.vala
+++ b/src/Panes/TerminalPane.vala
@@ -30,11 +30,11 @@ public class PantheonTweaks.Panes.TerminalPane : Categories.Pane {
     }
 
     construct {
-        if (!(Util.schema_exists (TERMINAL_OLD_SCHEMA) || Util.schema_exists (TERMINAL_NEW_SCHEMA))) {
+        if (!(schema_exists (TERMINAL_OLD_SCHEMA) || schema_exists (TERMINAL_NEW_SCHEMA))) {
             return;
         }
 
-        settings = new GLib.Settings ((Util.schema_exists (TERMINAL_NEW_SCHEMA)) ? TERMINAL_NEW_SCHEMA : TERMINAL_OLD_SCHEMA);
+        settings = new GLib.Settings ((schema_exists (TERMINAL_NEW_SCHEMA)) ? TERMINAL_NEW_SCHEMA : TERMINAL_OLD_SCHEMA);
 
         var background_color_label = new SummaryLabel (_("Background color:"));
         background_color_button = new Gtk.ColorButton () {

--- a/src/Settings/ThemeSettings.vala
+++ b/src/Settings/ThemeSettings.vala
@@ -17,12 +17,12 @@
  *
  */
 
-public class PantheonTweaks.Util {
+public class PantheonTweaks.ThemeSettings {
 
     /**
      * Gets and returns a list of the current themes by path and condition.
      */
-    public static Gee.List<string> get_themes (string path, string condition) {
+    private static Gee.List<string> get_themes (string path, string condition) {
         var themes = new Gee.ArrayList<string> ();
 
         string[] dirs = {
@@ -64,12 +64,5 @@ public class PantheonTweaks.Util {
         }
 
         return map;
-    }
-
-    /**
-     * Returns true if the schema exists.
-     */
-    public static bool schema_exists (string schema) {
-        return (SettingsSchemaSource.get_default ().lookup (schema, true) != null);
     }
 }

--- a/src/Widgets/Categories.vala
+++ b/src/Widgets/Categories.vala
@@ -88,6 +88,10 @@ public class PantheonTweaks.Categories : Gtk.Paned {
             content_area.margin_start = 60;
         }
 
+        protected bool schema_exists (string schema) {
+            return (SettingsSchemaSource.get_default ().lookup (schema, true) != null);
+        }
+
         protected void connect_combobox (Gtk.ComboBox box, Gtk.ListStore store, SetValue<string> set_func) {
             box.changed.connect (() => {
                 Value val;


### PR DESCRIPTION
`Util.vala` contains three methods; two are used in AppearancePane to get system/icon/cursor themes and another is used in some Panes to check the existence of schemes used in them. It would be fine of these methods to be in Utils if they are used wildly in the project, but it's not, so it would be even more make sense to put them into more suitable files.
