### PR TITLE
GtkSettings: Clean code

### DIFF
--- a/src/Panes/AppearancePane.vala
+++ b/src/Panes/AppearancePane.vala
@@ -34,7 +34,7 @@ public class PantheonTweaks.Panes.AppearancePane : Categories.Pane {
 
     construct {
         var interface_settings = new GLib.Settings ("org.gnome.desktop.interface");
-        var gtk_settings = GtkSettings.get_default ();
+        var gtk_settings = new GtkSettings ();
         x_settings = XSettings.get_default ();
         appearance_settings = new GLib.Settings ("org.pantheon.desktop.gala.appearance");
         var gnome_wm_settings = new GLib.Settings ("org.gnome.desktop.wm.preferences");

--- a/src/Settings/GtkSettings.vala
+++ b/src/Settings/GtkSettings.vala
@@ -16,93 +16,76 @@
  *
  */
 
-namespace PantheonTweaks {
+/**
+ * Settings for Gtk; thanks gnome-tweak-tool for the help!
+ */
+public class PantheonTweaks.GtkSettings : GLib.Object {
+    private GLib.KeyFile keyfile;
+    private string path;
 
     /**
-     * Settings for Gtk; thanks gnome-tweak-tool for the help!
+     * GTK should prefer the dark theme or not
      */
-    public class GtkSettings : GLib.Object {
-        private GLib.KeyFile keyfile;
-        private string path;
-        private static GtkSettings? instance = null;
-
-        /**
-         * GTK should prefer the dark theme or not
-         */
-        public bool prefer_dark_theme {
-            get {
-                if (!(File.new_for_path (path).query_exists ())) {
-                    return false;
-                }
-
-                return (get_integer ("gtk-application-prefer-dark-theme") == 1);
-            }
-            set { set_integer ("gtk-application-prefer-dark-theme", value ? 1 : 0); }
-        }
-
-        /**
-         * Creates a new GTKSettings
-         */
-        public GtkSettings () {
-            keyfile = new GLib.KeyFile ();
-
-            path = GLib.Environment.get_user_config_dir () + "/gtk-3.0/settings.ini";
-
+    public bool prefer_dark_theme {
+        get {
             if (!(File.new_for_path (path).query_exists ())) {
-                return;
+                return false;
             }
 
-            try {
-                keyfile.load_from_file (path, 0);
-            }
-            catch (Error e) {
-                warning ("Error loading GTK+ Keyfile settings.ini: " + e.message);
-            }
+            return (get_integer ("gtk-application-prefer-dark-theme") == 1);
+        }
+        set { set_integer ("gtk-application-prefer-dark-theme", value ? 1 : 0); }
+    }
+
+    public GtkSettings () {
+        keyfile = new GLib.KeyFile ();
+
+        path = GLib.Environment.get_user_config_dir () + "/gtk-3.0/settings.ini";
+
+        if (!(File.new_for_path (path).query_exists ())) {
+            return;
         }
 
-        public static GtkSettings get_default () {
-            if (instance == null)
-                instance = new GtkSettings ();
+        try {
+            keyfile.load_from_file (path, 0);
+        } catch (Error e) {
+            warning ("Error loading GTK+ Keyfile settings.ini: " + e.message);
+        }
+    }
 
-            return instance;
+    /**
+     * Gets an integer from the keyfile at Settings group
+     */
+    private int get_integer (string key) {
+        int key_int = 0;
+
+        try {
+            key_int = keyfile.get_integer ("Settings", key);
+        } catch (Error e) {
+            warning ("Error getting GTK+ int setting: " + e.message);
         }
 
-        /**
-         * Gets an integer from the keyfile at Settings group
-         */
-        private int get_integer (string key) {
-            int key_int = 0;
+        return key_int;
+    }
 
-            try {
-                key_int = keyfile.get_integer ("Settings", key);
-            }
-            catch (Error e) {
-                warning ("Error getting GTK+ int setting: " + e.message);
-            }
+    /**
+     * Sets an integer from the keyfile at Settings group
+     */
+    private void set_integer (string key, int val) {
+        keyfile.set_integer ("Settings", key, val);
 
-            return key_int;
-        }
+        save_keyfile ();
+    }
 
-        /**
-         * Sets an integer from the keyfile at Settings group
-         */
-        private void set_integer (string key, int val) {
-            keyfile.set_integer ("Settings", key, val);
-
-            save_keyfile ();
-        }
-
-        /**
-         * Saves the keyfile to disk
-         */
-        private void save_keyfile () {
-            try {
-                string data = keyfile.to_data();
-                GLib.FileUtils.set_contents(path, data);
-            }
-            catch (GLib.FileError e) {
-                warning ("Error saving GTK+ Keyfile settings.ini: " + e.message);
-            }
+    /**
+     * Saves the keyfile to disk
+     */
+    private void save_keyfile () {
+        try {
+            string data = keyfile.to_data ();
+            GLib.FileUtils.set_contents (path, data);
+        } catch (GLib.FileError e) {
+            warning ("Error saving GTK+ Keyfile settings.ini: " + e.message);
         }
     }
 }

--- a/src/Settings/GtkSettings.vala
+++ b/src/Settings/GtkSettings.vala
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) Elementary Tweaks Developers, 2014 - 2016
+ * Copyright (C) Elementary Tweaks Developers, 2014 - 2020
+ *               Pantheon Tweaks Developers, 2020
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
- Update copyright header
- Inline namespace
- Normal class initialization instead of singleton because the instance of GtkSettings is only used in AppearancePane
- Lint with vala-lint

Review in "Hide whitespace changes" mode.
