### PR TITLE
Hide PaneListItem if no schemas found

### DIFF
--- a/src/Panes/AnimationsPane.vala
+++ b/src/Panes/AnimationsPane.vala
@@ -28,7 +28,7 @@ public class PantheonTweaks.Panes.AnimationsPane : Categories.Pane {
     }
 
     construct {
-        if (!schema_exists (ANIMATIONS_SCHEMA)) {
+        if (!if_show_pane ({ ANIMATIONS_SCHEMA })) {
             return;
         }
 

--- a/src/Panes/AudiencePane.vala
+++ b/src/Panes/AudiencePane.vala
@@ -26,7 +26,7 @@ public class PantheonTweaks.Panes.AudiencePane : Categories.Pane {
     }
 
     construct {
-        if (!(schema_exists (VIDEOS_OLD_SCHEMA) || schema_exists (VIDEOS_NEW_SCHEMA))) {
+        if (!if_show_pane ({ VIDEOS_OLD_SCHEMA, VIDEOS_NEW_SCHEMA })) {
             return;
         }
 

--- a/src/Panes/FilesPane.vala
+++ b/src/Panes/FilesPane.vala
@@ -26,7 +26,7 @@ public class PantheonTweaks.Panes.FilesPane : Categories.Pane {
     }
 
     construct {
-        if (!(schema_exists (FILES_OLD_SCHEMA) || schema_exists (FILES_NEW_SCHEMA))) {
+        if (!if_show_pane ({ FILES_OLD_SCHEMA, FILES_NEW_SCHEMA })) {
             return;
         }
 

--- a/src/Panes/MiscPane.vala
+++ b/src/Panes/MiscPane.vala
@@ -28,7 +28,7 @@ public class PantheonTweaks.Panes.MiscPane : Categories.Pane {
     }
 
     construct {
-        if (!schema_exists (SOUND_SCHEMA)) {
+        if (!if_show_pane ({ SOUND_SCHEMA })) {
             return;
         }
 

--- a/src/Panes/TerminalPane.vala
+++ b/src/Panes/TerminalPane.vala
@@ -30,7 +30,7 @@ public class PantheonTweaks.Panes.TerminalPane : Categories.Pane {
     }
 
     construct {
-        if (!(schema_exists (TERMINAL_OLD_SCHEMA) || schema_exists (TERMINAL_NEW_SCHEMA))) {
+        if (!if_show_pane ({ TERMINAL_OLD_SCHEMA, TERMINAL_NEW_SCHEMA })) {
             return;
         }
 

--- a/src/Widgets/Categories.vala
+++ b/src/Widgets/Categories.vala
@@ -88,6 +88,17 @@ public class PantheonTweaks.Categories : Gtk.Paned {
             content_area.margin_start = 60;
         }
 
+        protected bool if_show_pane (string[] schemas) {
+            foreach (var schema in schemas) {
+                if (schema_exists (schema)) {
+                    return true;
+                }
+            }
+
+            pane_list_item.no_show_all = true;
+            return false;
+        }
+
         protected bool schema_exists (string schema) {
             return (SettingsSchemaSource.get_default ().lookup (schema, true) != null);
         }


### PR DESCRIPTION
## Before
![Screenshot from 2021-02-08 14-39-41](https://user-images.githubusercontent.com/26003928/107180192-9025f500-6a1b-11eb-9c15-018356e5e8ae.png)

If the schema id is can't be found for some reason (e.g. when elementary changed schema id of some components in favor of RDNNed id on Juno), the content of the pane is not shown. However, there are no error/debug messages so users can't find why the content isn't shown.

## After
![Screenshot from 2021-02-08 14-39-16](https://user-images.githubusercontent.com/26003928/107180197-9320e580-6a1b-11eb-951d-4e006641be18.png)

If the plug can't detect schemas, not only hide the content but also hide the pane and listbox itself because this means it's not available on the system implicitly.
This design pattern is how elementary do in the Mouse & Touchpad Plug; it hides the touchegg pane & row if it's not installed on the system.
