### PR TITLE
deb-packaging: Fix copyright

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -7,7 +7,8 @@ Upstream Author(s):
 
 Copyright:
 
-    Copyright (C) 2016-29 Elementary Tweaks Developers
+    Copyright (C) 2014 - 2020 Elementary Tweaks Developers
+                  2020 - 2021 Pantheon Tweaks Developers
 
 License:
 
@@ -29,6 +30,7 @@ Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
 
 The Debian packaging is:
 
-    Copyright (C) 2016 Elementary Tweaks Developers
+    Copyright (C) 2014 - 2020 Elementary Tweaks Developers
+                  2020 - 2021 Pantheon Tweaks Developers
 
 and is licensed under the GPL version 3, see above.


### PR DESCRIPTION
Follows the copyright header in vala files.
