### PR TITLE
MiscPane: Fix resetting max volume does not work

### DIFF
--- a/src/Panes/MiscPane.vala
+++ b/src/Panes/MiscPane.vala
@@ -19,6 +19,8 @@
 
 public class PantheonTweaks.Panes.MiscPane : Categories.Pane {
     private const string SOUND_SCHEMA = "io.elementary.desktop.wingpanel.sound";
+    
+    private GLib.Settings sound_settings;
 
     public MiscPane () {
         base (
@@ -32,7 +34,7 @@ public class PantheonTweaks.Panes.MiscPane : Categories.Pane {
             return;
         }
 
-        var sound_settings = new GLib.Settings (SOUND_SCHEMA);
+        sound_settings = new GLib.Settings (SOUND_SCHEMA);
 
         var indicator_sound_label = new Granite.HeaderLabel (_("Sound Indicator"));
 


### PR DESCRIPTION
You can't reset the max volume in the main branch and will get the following error message:

```
(io.elementary.switchboard:8102): GLib-GIO-CRITICAL **: 16:05:25.693: g_settings_reset: assertion 'G_IS_SETTINGS (settings)' failed
```
