### PR TITLE
Lint using vala-lint

### DIFF
--- a/src/Panes/AppearancePane.vala
+++ b/src/Panes/AppearancePane.vala
@@ -81,7 +81,9 @@ public class PantheonTweaks.Panes.AppearancePane : Categories.Pane {
         var dark_style_label = new SummaryLabel (_("Force to use dark stylesheet:"));
         var dark_style_switch = new Switch ();
         dark_style_switch.state = gtk_settings.prefer_dark_theme;
-        var prefer_dark_info = new DimLabel (_("Forces dark style on all apps, even if it's not supported. Requires restarting the application."));
+        var prefer_dark_info = new DimLabel (
+            _("Forces dark style on all apps, even if it's not supported. Requires restarting the application.")
+        );
 
         var layout_label = new Granite.HeaderLabel (_("Window Controls"));
 

--- a/src/Panes/TerminalPane.vala
+++ b/src/Panes/TerminalPane.vala
@@ -34,7 +34,9 @@ public class PantheonTweaks.Panes.TerminalPane : Categories.Pane {
             return;
         }
 
-        settings = new GLib.Settings ((schema_exists (TERMINAL_NEW_SCHEMA)) ? TERMINAL_NEW_SCHEMA : TERMINAL_OLD_SCHEMA);
+        settings = new GLib.Settings (
+            (schema_exists (TERMINAL_NEW_SCHEMA)) ? TERMINAL_NEW_SCHEMA : TERMINAL_OLD_SCHEMA
+        );
 
         var background_color_label = new SummaryLabel (_("Background color:"));
         background_color_button = new Gtk.ColorButton () {
@@ -44,7 +46,9 @@ public class PantheonTweaks.Panes.TerminalPane : Categories.Pane {
 
         var follow_last_tab_label = new SummaryLabel (_("Follow last tab:"));
         var follow_last_tab_switch = new Switch ();
-        var follow_last_tab_info = new DimLabel (_("Creating a new tab sets the working directory of the last opened tab."));
+        var follow_last_tab_info = new DimLabel (
+            _("Creating a new tab sets the working directory of the last opened tab.")
+        );
 
         var unsafe_paste_alert_label = new SummaryLabel (_("Unsafe paste alert:"));
         var unsafe_paste_alert_switch = new Switch ();
@@ -56,7 +60,9 @@ public class PantheonTweaks.Panes.TerminalPane : Categories.Pane {
 
         var term_bell_label = new SummaryLabel (_("Terminal bell:"));
         var term_bell_switch = new Switch ();
-        var term_bell_info = new DimLabel (_("Sound when hitting the end of a line and also for tab-completion when there are either no or multiple possible completions."));
+        var term_bell_info = new DimLabel (
+            _("Sound when hitting the end of a line and also for tab-completion when there are either no or multiple possible completions.") // vala-lint=line-length
+        );
 
         content_area.attach (background_color_label, 0, 0, 1, 1);
         content_area.attach (background_color_button, 1, 0, 1, 1);


### PR DESCRIPTION
Fix the following lint warnings:

```
src/Panes/AppearancePane.vala
   84.120   warn    Line exceeds limit of 120 characters (currently 147 characters)   line-length
src/Panes/TerminalPane.vala
   37.120   warn    Line exceeds limit of 120 characters (currently 121 characters)   line-length
   47.120   warn    Line exceeds limit of 120 characters (currently 125 characters)   line-length
   59.120   warn    Line exceeds limit of 120 characters (currently 173 characters)   line-length
```
