### PR TITLE
ThemeSettings: Ignore Adwaita/gnome/hicolor themes

### DIFF
--- a/data/pantheon-tweaks.appdata.xml.in
+++ b/data/pantheon-tweaks.appdata.xml.in
@@ -14,7 +14,6 @@
   <releases>
     <release version="1.0.1" date="2021-08-11" urgency="low">
       <description>
-        <p>elementary Tweaks is now renamed to Pantheon Tweaks and get some new features and fixes:</p>
         <ul>
           <li>Exclude Adwaita/gnome/hicolor themes from theme selections</li>
         </ul>

--- a/data/pantheon-tweaks.appdata.xml.in
+++ b/data/pantheon-tweaks.appdata.xml.in
@@ -12,6 +12,14 @@
   <icon type="stock">preferences-desktop-tweaks</icon>
   <translation type="gettext">pantheon-tweaks-plug</translation>
   <releases>
+    <release version="1.0.1" date="2021-08-11" urgency="low">
+      <description>
+        <p>elementary Tweaks is now renamed to Pantheon Tweaks and get some new features and fixes:</p>
+        <ul>
+          <li>Exclude Adwaita/gnome/hicolor themes from theme selections</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.0.0" date="2021-08-05" urgency="medium">
       <description>
         <p>elementary Tweaks is now renamed to Pantheon Tweaks and get some new features and fixes:</p>

--- a/src/Settings/ThemeSettings.vala
+++ b/src/Settings/ThemeSettings.vala
@@ -19,7 +19,7 @@
 
 public class PantheonTweaks.ThemeSettings {
     private const string[] IGNORE_LIST = {
-        "Emacs", "Default", "default", "Adwaita", "gnome", "hicolor"
+        "Adwaita", "Emacs", "Default", "default", "gnome", "hicolor"
     };
 
     /**

--- a/src/Settings/ThemeSettings.vala
+++ b/src/Settings/ThemeSettings.vala
@@ -18,6 +18,9 @@
  */
 
 public class PantheonTweaks.ThemeSettings {
+    private const string[] IGNORE_LIST = {
+        "Emacs", "Default", "default", "Adwaita", "gnome", "hicolor"
+    };
 
     /**
      * Gets and returns a list of the current themes by path and condition.
@@ -41,11 +44,15 @@ public class PantheonTweaks.ThemeSettings {
                 FileInfo file_info;
                 while ((file_info = enumerator.next_file ()) != null) {
                     var name = file_info.get_name ();
+                    if (name in IGNORE_LIST) {
+                        continue;
+                    }
+
                     var checktheme = File.new_for_path (dir + name + "/" + condition);
                     var checkicons = File.new_for_path (dir + name + "/48x48/" + condition);
-                    if ((checktheme.query_exists () || checkicons.query_exists ()) &&
-                            name != "Emacs" && name != "Default" && name != "default" && !themes.contains (name))
+                    if ((checktheme.query_exists () || checkicons.query_exists ()) && !themes.contains (name)) {
                         themes.add (name);
+                    }
                 }
             } catch (Error e) {
                 warning (e.message);


### PR DESCRIPTION
These themes looks broken on Pantheon so don't show them in the theme chooser.
