### PR TITLE
build: fix install path for switchboard plug

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,8 @@ project('pantheon-tweaks', 'vala', 'c', version: '1.0.0')
 
 switchboard_dep = dependency('switchboard-2.0')
 gettext_name = meson.project_name() + '-plug'
-pkgdatadir = join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir'), 'personal')
+libdir = join_paths(get_option('prefix'), get_option('libdir'))
+pkgdatadir = join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir]), 'personal')
 
 i18n = import('i18n')
 


### PR DESCRIPTION
We are trying to package this on NixOS (as requested in https://github.com/NixOS/nixpkgs/issues/115222 and https://github.com/NixOS/nixpkgs/issues/135376), on NixOS all packages are installed into their own immutable prefix. Because of this `switchboard_dep.get_pkgconfig_variable` will return a path from within switchboard's prefix and we cannot write to it. By using `define_variable` we can replace the `libdir` to be from the paths from meson. I think this should have no affect on elementary OS. 

Similar PR: https://github.com/elementary/switchboard-plug-about/pull/100.

Thanks for reviewing this!
