### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,15 @@ add_global_arguments(
     language:'c'
 )
 
+config_data = configuration_data()
+config_data.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+config_data.set_quoted('GETTEXT_PACKAGE', gettext_name)
+config_file = configure_file(
+    input: 'src/Config.vala.in',
+    output: '@BASENAME@',
+    configuration: config_data
+)
+
 subdir('data')
 subdir('po')
 
@@ -32,6 +41,7 @@ plug_files = files(
 shared_module(
     meson.project_name(),
     plug_files,
+    config_file,
     dependencies: [
         dependency('gee-0.8'),
         dependency('glib-2.0'),

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,0 +1,2 @@
+public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+public const string LOCALEDIR = @LOCALEDIR@;

--- a/src/Tweaks.vala
+++ b/src/Tweaks.vala
@@ -21,6 +21,9 @@ public class PantheonTweaks.TweaksPlug : Switchboard.Plug {
     private PantheonTweaks.Categories categories;
 
     public TweaksPlug () {
+        GLib.Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+
         var settings = new Gee.TreeMap<string, string?> (null, null);
         settings.set ("tweaks", null);
         settings.set ("tweaks/appearance", "appearance");


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are trying to package this on NixOS (as requested in https://github.com/NixOS/nixpkgs/issues/115222 and https://github.com/NixOS/nixpkgs/issues/135376), and due to NixOS 's special `localedir`, we cannot apply the translations without this patch. I think this should have no affect on elementary OS.

Similar PR: https://github.com/elementary/switchboard-plug-about/pull/229.

Thanks for reviewing this!
