### PR TITLE
FontsPane: Fix icon missing with the latest icons update

### DIFF
--- a/src/Panes/FontsPane.vala
+++ b/src/Panes/FontsPane.vala
@@ -20,7 +20,7 @@
 public class PantheonTweaks.Panes.FontsPane : Categories.Pane {
     public FontsPane () {
         base (
-            _("Fonts"), "applications-fonts",
+            _("Fonts"), "preferences-desktop-font",
             _("Change the fonts used in your system and documents by default.")
         );
     }


### PR DESCRIPTION
The `applications-fonts` was renamed in https://github.com/elementary/icons/commit/946e0d82e004bd1548d837588ec540983d5a84f2
