### PR TITLE
Revert "meson: Replace join_paths with '/' (#137)"

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,12 +1,12 @@
 install_data(
     'preferences-desktop-tweaks.svg',
-    install_dir: get_option('datadir') / 'icons' / 'hicolor' / '32x32' / 'categories'
+    install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', '32x32', 'categories')
 )
 
 i18n.merge_file(
     input: meson.project_name() + '.appdata.xml.in',
     output: meson.project_name() + '.appdata.xml',
-    po_dir: meson.source_root () / 'po',
-    install_dir: get_option('prefix') / get_option('datadir') / 'metainfo',
+    po_dir: join_paths(meson.source_root (), 'po'),
+    install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'metainfo'),
     install: true
 )

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>= 10.5.1),
                libgee-0.8-dev,
                libswitchboard-2.0-dev,
                meson,
-               valac (>= 0.49.0)
+               valac (>= 0.30)
 Standards-Version: 4.5.0
 Homepage: https://github.com/pantheon-tweaks/pantheon-tweaks
 

--- a/meson.build
+++ b/meson.build
@@ -1,14 +1,9 @@
-project(
-    'pantheon-tweaks',
-    'vala', 'c',
-    version: '1.0.2',
-    meson_version: '>= 0.49.0'
-)
+project('pantheon-tweaks', 'vala', 'c', version: '1.0.2')
 
 switchboard_dep = dependency('switchboard-2.0')
 gettext_name = meson.project_name() + '-plug'
-libdir = get_option('prefix') / get_option('libdir')
-pkgdatadir = switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir]) / 'personal'
+libdir = join_paths(get_option('prefix'), get_option('libdir'))
+pkgdatadir = join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir]), 'personal')
 
 i18n = import('i18n')
 
@@ -18,10 +13,10 @@ add_global_arguments(
 )
 
 config_data = configuration_data()
-config_data.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))
+config_data.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
 config_data.set_quoted('GETTEXT_PACKAGE', gettext_name)
 config_file = configure_file(
-    input: 'src' / 'Config.vala.in',
+    input: 'src/Config.vala.in',
     output: '@BASENAME@',
     configuration: config_data
 )
@@ -30,18 +25,18 @@ subdir('data')
 subdir('po')
 
 plug_files = files(
-    'src' / 'Tweaks.vala',
-    'src' / 'Settings' / 'AccountsService.vala',
-    'src' / 'Settings' / 'GtkSettings.vala',
-    'src' / 'Settings' / 'ThemeSettings.vala',
-    'src' / 'Settings' / 'XSettings.vala',
-    'src' / 'Panes' / 'AnimationsPane.vala',
-    'src' / 'Panes' / 'AppearancePane.vala',
-    'src' / 'Panes' / 'FontsPane.vala',
-    'src' / 'Panes' / 'MiscPane.vala',
-    'src' / 'Panes' / 'FilesPane.vala',
-    'src' / 'Panes' / 'TerminalPane.vala',
-    'src' / 'Widgets' / 'Categories.vala'
+    'src/Tweaks.vala',
+    'src/Settings/AccountsService.vala',
+    'src/Settings/GtkSettings.vala',
+    'src/Settings/ThemeSettings.vala',
+    'src/Settings/XSettings.vala',
+    'src/Panes/AnimationsPane.vala',
+    'src/Panes/AppearancePane.vala',
+    'src/Panes/FontsPane.vala',
+    'src/Panes/MiscPane.vala',
+    'src/Panes/FilesPane.vala',
+    'src/Panes/TerminalPane.vala',
+    'src/Widgets/Categories.vala',
 )
 
 shared_module(
@@ -60,4 +55,4 @@ shared_module(
     install_dir: pkgdatadir
 )
 
-meson.add_install_script('meson' / 'post_install.py')
+meson.add_install_script('meson/post_install.py')


### PR DESCRIPTION
I believed the latest version of valac on focal is 0.5x but it's not :sweat_smile:

```
ryonakano@ryonakano-pc:~/Projects/pantheon-tweaks$ LANG=C apt-cache policy valac
valac:
  Installed: 0.48.20-0ubuntu1~20.04~valateam0
  Candidate: 0.48.20-0ubuntu1~20.04~valateam0
  Version table:
 *** 0.48.20-0ubuntu1~20.04~valateam0 999
        999 http://ppa.launchpad.net/elementary-os/os-patches/ubuntu focal/main amd64 Packages
        100 /var/lib/dpkg/status
     0.48.6-0ubuntu1 500
        500 mirror://mirrors.ubuntu.com/mirrors.txt focal-updates/universe amd64 Packages
     0.48.3-1 500
        500 mirror://mirrors.ubuntu.com/mirrors.txt focal/universe amd64 Packages
```

We need to revert this for now until 0.49.0 or later get available on focal
