### PR TITLE
TerminalPane: Remove background color preference

### DIFF
--- a/src/Panes/TerminalPane.vala
+++ b/src/Panes/TerminalPane.vala
@@ -22,8 +22,6 @@ public class PantheonTweaks.Panes.TerminalPane : Categories.Pane {
 
     private GLib.Settings settings;
 
-    private Gtk.ColorButton background_color_button;
-
     public TerminalPane () {
         base (_("Terminal"), "utilities-terminal");
     }
@@ -34,12 +32,6 @@ public class PantheonTweaks.Panes.TerminalPane : Categories.Pane {
         }
 
         settings = new GLib.Settings (TERMINAL_SCHEMA);
-
-        var background_color_label = new SummaryLabel (_("Background color:"));
-        background_color_button = new Gtk.ColorButton () {
-            halign = Gtk.Align.START,
-            use_alpha = true
-        };
 
         var follow_last_tab_label = new SummaryLabel (_("Follow last tab:"));
         var follow_last_tab_switch = new Switch ();
@@ -69,30 +61,22 @@ public class PantheonTweaks.Panes.TerminalPane : Categories.Pane {
         var tab_bar_label = new SummaryLabel (_("Show tabs:"));
         var tab_bar_combo = new ComboBoxText (tab_bar_map);
 
-        content_area.attach (background_color_label, 0, 0, 1, 1);
-        content_area.attach (background_color_button, 1, 0, 1, 1);
-        content_area.attach (follow_last_tab_label, 0, 1, 1, 1);
-        content_area.attach (follow_last_tab_switch, 1, 1, 1, 1);
-        content_area.attach (follow_last_tab_info, 1, 2, 1, 1);
-        content_area.attach (unsafe_paste_alert_label, 0, 3, 1, 1);
-        content_area.attach (unsafe_paste_alert_switch, 1, 3, 1, 1);
-        content_area.attach (unsafe_paste_alert_info, 1, 4, 1, 1);
-        content_area.attach (rem_tabs_label, 0, 5, 1, 1);
-        content_area.attach (rem_tabs_switch, 1, 5, 1, 1);
-        content_area.attach (rem_tabs_info, 1, 6, 1, 1);
-        content_area.attach (term_bell_label, 0, 7, 1, 1);
-        content_area.attach (term_bell_switch, 1, 7, 1, 1);
-        content_area.attach (term_bell_info, 1, 8, 1, 1);
-        content_area.attach (tab_bar_label, 0, 9, 1, 1);
-        content_area.attach (tab_bar_combo, 1, 9, 1, 1);
+        content_area.attach (follow_last_tab_label, 0, 0, 1, 1);
+        content_area.attach (follow_last_tab_switch, 1, 0, 1, 1);
+        content_area.attach (follow_last_tab_info, 1, 1, 1, 1);
+        content_area.attach (unsafe_paste_alert_label, 0, 2, 1, 1);
+        content_area.attach (unsafe_paste_alert_switch, 1, 2, 1, 1);
+        content_area.attach (unsafe_paste_alert_info, 1, 3, 1, 1);
+        content_area.attach (rem_tabs_label, 0, 4, 1, 1);
+        content_area.attach (rem_tabs_switch, 1, 4, 1, 1);
+        content_area.attach (rem_tabs_info, 1, 5, 1, 1);
+        content_area.attach (term_bell_label, 0, 6, 1, 1);
+        content_area.attach (term_bell_switch, 1, 6, 1, 1);
+        content_area.attach (term_bell_info, 1, 7, 1, 1);
+        content_area.attach (tab_bar_label, 0, 8, 1, 1);
+        content_area.attach (tab_bar_combo, 1, 8, 1, 1);
 
         show_all ();
-
-        update_background_value ();
-
-        background_color_button.color_set.connect (() => {
-            settings.set_string ("background", background_color_button.rgba.to_string ());
-        });
 
         settings.bind ("follow-last-tab", follow_last_tab_switch, "active", SettingsBindFlags.DEFAULT);
         settings.bind ("unsafe-paste-alert", unsafe_paste_alert_switch, "active", SettingsBindFlags.DEFAULT);
@@ -101,20 +85,12 @@ public class PantheonTweaks.Panes.TerminalPane : Categories.Pane {
         settings.bind ("tab-bar-behavior", tab_bar_combo, "active_id", SettingsBindFlags.DEFAULT);
 
         on_click_reset (() => {
-            string[] keys = {"background", "unsafe-paste-alert", "natural-copy-paste",
+            string[] keys = {"unsafe-paste-alert", "natural-copy-paste",
                              "follow-last-tab", "audible-bell", "remember-tabs", "tab-bar-behavior"};
 
             foreach (string key in keys) {
                 settings.reset (key);
             }
-
-            update_background_value ();
         });
-    }
-
-    private void update_background_value () {
-        var rgba = Gdk.RGBA ();
-        rgba.parse (settings.get_string ("background"));
-        background_color_button.rgba = rgba;
     }
 }


### PR DESCRIPTION
Terminal now comes with color pallet feature starting from [6.1.0](https://github.com/elementary/terminal/releases/tag/6.1.0) (which is also available on current stable―Jólnir). And with that feature we can customize not only the background color but also font color, cursor color, and more.

Also, as far as I confirmed on elementary OS Early Access 7 this background preference no longer takes effect on Terminal.

These are the reasons why I decided to remove this preference from Pantheon Tweaks.