### PR TITLE
meson: Use newer syntax

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -6,7 +6,7 @@ install_data(
 i18n.merge_file(
     input: meson.project_name() + '.metainfo.xml.in',
     output: meson.project_name() + '.metainfo.xml',
-    po_dir: meson.project_source_root () / 'po',
+    po_dir: meson.source_root () / 'po',
     install_dir: get_option('prefix') / get_option('datadir') / 'metainfo',
     install: true
 )

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,12 +1,12 @@
 install_data(
     'preferences-desktop-tweaks.svg',
-    install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', '32x32', 'categories')
+    install_dir: get_option('datadir') / 'icons' / 'hicolor' / '32x32' / 'categories'
 )
 
 i18n.merge_file(
     input: meson.project_name() + '.metainfo.xml.in',
     output: meson.project_name() + '.metainfo.xml',
-    po_dir: join_paths(meson.source_root (), 'po'),
-    install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'metainfo'),
+    po_dir: meson.project_source_root () / 'po',
+    install_dir: get_option('prefix') / get_option('datadir') / 'metainfo',
     install: true
 )

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: appstream,
                libglib2.0-dev,
                libgee-0.8-dev,
                libswitchboard-2.0-dev,
-               meson (>= 0.57.0),
+               meson (>= 0.51.0),
                valac (>= 0.30)
 Standards-Version: 4.5.0
 Homepage: https://github.com/pantheon-tweaks/pantheon-tweaks

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: appstream,
                libglib2.0-dev,
                libgee-0.8-dev,
                libswitchboard-2.0-dev,
-               meson,
+               meson (>= 0.57.0),
                valac (>= 0.30)
 Standards-Version: 4.5.0
 Homepage: https://github.com/pantheon-tweaks/pantheon-tweaks

--- a/meson.build
+++ b/meson.build
@@ -1,14 +1,16 @@
 project(
     'pantheon-tweaks',
     'vala', 'c',
-    version: '1.0.4'
+    version: '1.0.4',
+    meson_version: '>= 0.57.0'
 )
 
 switchboard_dep = dependency('switchboard-2.0')
 gettext_name = meson.project_name() + '-plug'
-libdir = join_paths(get_option('prefix'), get_option('libdir'))
-pkgdatadir = join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir]), 'personal')
+libdir = get_option('prefix') / get_option('libdir')
+pkgdatadir = switchboard_dep.get_variable(pkgconfig: 'plugsdir', pkgconfig_define: ['libdir', libdir]) / 'personal'
 
+gnome = import('gnome')
 i18n = import('i18n')
 
 add_global_arguments(
@@ -17,12 +19,16 @@ add_global_arguments(
 )
 
 config_data = configuration_data()
-config_data.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+config_data.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))
 config_data.set_quoted('GETTEXT_PACKAGE', gettext_name)
 config_file = configure_file(
     input: 'src/Config.vala.in',
     output: '@BASENAME@',
     configuration: config_data
+)
+
+gnome.post_install(
+    gtk_update_icon_cache: true
 )
 
 subdir('data')
@@ -57,5 +63,3 @@ shared_module(
     install: true,
     install_dir: pkgdatadir
 )
-
-meson.add_install_script('meson/post_install.py')

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
     'pantheon-tweaks',
     'vala', 'c',
     version: '1.0.4',
-    meson_version: '>= 0.57.0'
+    meson_version: '>= 0.51.0'
 )
 
 switchboard_dep = dependency('switchboard-2.0')
@@ -10,7 +10,6 @@ gettext_name = meson.project_name() + '-plug'
 libdir = get_option('prefix') / get_option('libdir')
 pkgdatadir = switchboard_dep.get_variable(pkgconfig: 'plugsdir', pkgconfig_define: ['libdir', libdir]) / 'personal'
 
-gnome = import('gnome')
 i18n = import('i18n')
 
 add_global_arguments(
@@ -25,10 +24,6 @@ config_file = configure_file(
     input: 'src/Config.vala.in',
     output: '@BASENAME@',
     configuration: config_data
-)
-
-gnome.post_install(
-    gtk_update_icon_cache: true
 )
 
 subdir('data')
@@ -63,3 +58,5 @@ shared_module(
     install: true,
     install_dir: pkgdatadir
 )
+
+meson.add_install_script('meson/post_install.py')

--- a/meson/post_install.py
+++ b/meson/post_install.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+from os import environ, path
+from subprocess import call
+
+if not environ.get('DESTDIR'):
+    install_prefix = environ.get('MESON_INSTALL_PREFIX')
+    print('Updating icon cache…')
+    call(['gtk-update-icon-cache', '-qtf', path.join(install_prefix, 'share/icons/hicolor')])

--- a/meson/post_install.py
+++ b/meson/post_install.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-
-from os import environ, path
-from subprocess import call
-
-if not environ.get('DESTDIR'):
-    install_prefix = environ.get('MESON_INSTALL_PREFIX')
-    print('Updating icon cache…')
-    call(['gtk-update-icon-cache', '-qtf', path.join(install_prefix, 'share/icons/hicolor')])

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,6 +1,5 @@
 i18n.gettext(gettext_name,
     args: [
-        '--directory=' + meson.source_root(),
         '--from-code=UTF-8',
         '-cTRANSLATORS'
     ],


### PR DESCRIPTION
- Use `/` instead of `join_paths()` (added in [0.49.0](https://mesonbuild.com/Reference-manual_functions.html#join_paths))
- Use `get_variable()` instead of deprecated `get_pkgconfig_variable()` (added in [0.51.0](https://mesonbuild.com/Reference-manual_returned_dep.html#depget_variable))
- Remove unnecessary `--directory` argument from gettext

As a result we now require meson >= 0.51.0 with these changes.