### PR TITLE
Remove DestinationButton to lessen fileaccess permission

### DIFF
--- a/io.github.pantheon_tweaks.pantheon-tweaks.yml
+++ b/io.github.pantheon_tweaks.pantheon-tweaks.yml
@@ -9,11 +9,12 @@ finish-args:
   - '--socket=wayland'
   - '--socket=fallback-x11'
 
-  # Grant read, write, and create access for settings.ini of GTK and theme dirs
-  - '--filesystem=home/.config/gtk-3.0:create'
-  - '--filesystem=home/.icons:create'
-  - '--filesystem=home/.local/share/sounds:create'
-  - '--filesystem=home/.local/share/themes:create'
+  # Grant read and write access for settings.ini of GTK
+  - '--filesystem=home/.config/gtk-3.0:rw'
+  # Grant read access for theme dirs
+  - '--filesystem=home/.icons:ro'
+  - '--filesystem=home/.local/share/sounds:ro'
+  - '--filesystem=home/.local/share/themes:ro'
   # Pass the directory where the host's /usr is mounted under, so that we can load system theme files
   - '--env=USR_DIR_PREFIX=/var/run/host'
 

--- a/src/Panes/AppearancePane.vala
+++ b/src/Panes/AppearancePane.vala
@@ -71,8 +71,6 @@ public class PantheonTweaks.Panes.AppearancePane : Categories.Pane {
             "~/.local/share/themes/<%s>/gtk-3.0".printf (_("theme-name"))
         ));
 
-        var gtk_dir_button = new DestinationButton (".local/share/themes");
-
         var icon_label = new SummaryLabel (_("Icons:"));
         var icon_list = ThemeSettings.get_themes ("icons", "index.theme");
         var icon_combobox = new ComboBoxText.from_list (icon_list);
@@ -81,8 +79,6 @@ public class PantheonTweaks.Panes.AppearancePane : Categories.Pane {
         var icon_info = new DimLabel (_("To show custom icons here, put them in %s.").printf (
             "~/.icons/<%s>".printf (_("theme-name"))
         ));
-
-        var icon_dir_button = new DestinationButton (".icons");
 
         var cursor_label = new SummaryLabel (_("Cursor:"));
         var cursor_list = ThemeSettings.get_themes ("icons", "cursors");
@@ -93,8 +89,6 @@ public class PantheonTweaks.Panes.AppearancePane : Categories.Pane {
             "~/.icons/<%s>/cursors".printf (_("theme-name"))
         ));
 
-        var cursor_dir_button = new DestinationButton (".icons");
-
         var sound_label = new SummaryLabel (_("Sound:"));
         var sound_list = ThemeSettings.get_themes ("sounds", "index.theme");
         var sound_combobox = new ComboBoxText.from_list (sound_list);
@@ -103,8 +97,6 @@ public class PantheonTweaks.Panes.AppearancePane : Categories.Pane {
         var sound_info = new DimLabel (_("To show custom sounds here, put them in %s.").printf (
             "~/.local/share/sounds/<%s>".printf (_("theme-name"))
         ));
-
-        var sound_dir_button = new DestinationButton (".local/share/sounds");
 
         var dark_style_label = new SummaryLabel (_("Force to use dark stylesheet:"));
         var dark_style_switch = new Switch ();
@@ -130,19 +122,15 @@ public class PantheonTweaks.Panes.AppearancePane : Categories.Pane {
         content_area.attach (gtk_label, 0, 1, 1, 1);
         content_area.attach (gtk_combobox, 1, 1, 1, 1);
         content_area.attach (gtk_info, 1, 2, 1, 1);
-        content_area.attach (gtk_dir_button, 2, 2, 1, 1);
         content_area.attach (icon_label, 0, 3, 1, 1);
         content_area.attach (icon_combobox, 1, 3, 1, 1);
         content_area.attach (icon_info, 1, 4, 1, 1);
-        content_area.attach (icon_dir_button, 2, 4, 1, 1);
         content_area.attach (cursor_label, 0, 5, 1, 1);
         content_area.attach (cursor_combobox, 1, 5, 1, 1);
         content_area.attach (cursor_info, 1, 6, 1, 1);
-        content_area.attach (cursor_dir_button, 2, 6, 1, 1);
         content_area.attach (sound_label, 0, 7, 1, 1);
         content_area.attach (sound_combobox, 1, 7, 1, 1);
         content_area.attach (sound_info, 1, 8, 1, 1);
-        content_area.attach (sound_dir_button, 2, 8, 1, 1);
         content_area.attach (dark_style_label, 0, 9, 1, 1);
         content_area.attach (dark_style_switch, 1, 9, 1, 1);
         content_area.attach (prefer_dark_info, 1, 10, 1, 1);

--- a/src/Widgets/Categories.vala
+++ b/src/Widgets/Categories.vala
@@ -207,60 +207,6 @@ public class PantheonTweaks.Categories : Gtk.Paned {
             }
         }
 
-        protected class DestinationButton : Gtk.Button {
-            public string destination_uri { private get; construct; }
-
-            public DestinationButton (string destination) {
-                Object (
-                    image: new Gtk.Image.from_icon_name ("folder-open", Gtk.IconSize.BUTTON),
-                    destination_uri: "file://%s/%s".printf (Environment.get_home_dir (), destination),
-                    valign: Gtk.Align.START,
-                    tooltip_text: _("Open destination folder")
-                );
-            }
-
-            construct {
-                clicked.connect (() => {
-                    var dir = File.new_for_uri (destination_uri);
-                    if (!dir.query_exists ()) {
-                        try {
-                            dir.make_directory_with_parents ();
-                        } catch (Error e) {
-                            show_folder_action_error (
-                                _("Failed to create the destination folder"),
-                                _("The destination folder doesn't exist and tried to create new but failed. The following error message might be helpful:"),
-                                e.message
-                            );
-                        }
-                    }
-
-                    try {
-                        GLib.AppInfo.launch_default_for_uri (destination_uri, null);
-                    } catch (Error e) {
-                        show_folder_action_error (
-                            _("Failed to open the destination folder"),
-                            _("Tried to open the destination folder but failed. The following error message might be helpful:"),
-                            e.message
-                        );
-                    }
-                });
-            }
-
-            private void show_folder_action_error (string primary_text, string secondary_text, string error_message) {
-                var error_dialog = new Granite.MessageDialog.with_image_from_icon_name (
-                    primary_text, secondary_text, "dialog-error", Gtk.ButtonsType.CLOSE
-                ) {
-                    modal = true,
-                    transient_for = (Gtk.Window) get_toplevel ()
-                };
-                error_dialog.show_error_details (error_message);
-                error_dialog.response.connect ((response_id) => {
-                    error_dialog.destroy ();
-                });
-                error_dialog.show ();
-            }
-        }
-
         protected class SummaryLabel : Gtk.Label {
             public SummaryLabel (string label) {
                 Object (label: label);


### PR DESCRIPTION
DestinationButton tries to mkdir the given directory if it does not exist. This is helpful but requires additional create permission, which is not recommended in the world of Flatpak for security.

So, this commit removes DestinationButton completely and makes sure that now Tweaks doesn't require write and create access permission for these directories. Users now need to open each directory manually from file managers, but this just gets things back before #135.

This commit also removes the meaningless create permission for ~/.config/gtk-3.0 directory. We don't care absence of that directory at all in our code.