### PR TITLE
DestinationButton: Fix double error dialog when directory creation failed

### DIFF
--- a/src/Widgets/Categories.vala
+++ b/src/Widgets/Categories.vala
@@ -231,6 +231,8 @@ public class PantheonTweaks.Categories : Gtk.Paned {
                                 _("The destination folder doesn't exist and tried to create new but failed. The following error message might be helpful:"),
                                 e.message
                             );
+
+                            return;
                         }
                     }
 


### PR DESCRIPTION
This route failed to create directory, so don't try to open the directory that does not exist.