### PR TITLE
Replace Granite.SimpleSettingsPage with Switchboard.SettingsPage

### DIFF
--- a/0001-lib-Include-stylesheet-in-the-library.patch
+++ b/0001-lib-Include-stylesheet-in-the-library.patch
@@ -1,0 +1,27 @@
+From 2b8c1f1e2b75e7eb6f3e79c294a74e547960de76 Mon Sep 17 00:00:00 2001
+From: Ryo Nakano <ryonakaknock3@gmail.com>
+Date: Sat, 29 Jun 2024 08:52:04 +0000
+Subject: [PATCH] lib: Include stylesheet in the library
+
+Export the stylesheet resource as a part of the library
+so that we can use libswitchboard as a widget library
+from other apps, not from Switchboard plugs.
+---
+ lib/meson.build | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/meson.build b/lib/meson.build
+index 5f5f733..922766b 100644
+--- a/lib/meson.build
++++ b/lib/meson.build
+@@ -26,6 +26,7 @@ libswitchboard_lib = library('switchboard-3',
+     'SettingsSidebarRow.vala',
+     'SettingsSidebar.vala',
+     config_header,
++    stylesheet_resource,
+     dependencies: [libswitchboard_deps, config_vapi],
+     vala_header: 'switchboard.h',
+     soversion: '0',
+-- 
+2.43.0
+

--- a/io.github.pantheon_tweaks.pantheon-tweaks.yml
+++ b/io.github.pantheon_tweaks.pantheon-tweaks.yml
@@ -101,6 +101,13 @@ modules:
 
   - name: switchboard
     buildsystem: meson
+    cleanup:
+      # We use switchboard as a widget library; cleanup the unnecessary system settings app
+      - '/share/applications'
+      - '/share/metainfo'
+      - '/bin'
+      - '/share/glib-2.0/schemas/io.elementary.settings.gschema.xml'
+      - '/share/icons'
     sources:
       - type: archive
         url: https://github.com/elementary/switchboard/archive/refs/tags/8.0.0.tar.gz

--- a/io.github.pantheon_tweaks.pantheon-tweaks.yml
+++ b/io.github.pantheon_tweaks.pantheon-tweaks.yml
@@ -39,6 +39,7 @@ modules:
       - '-Dbash_completion=false'
       - '-Dman=false'
     cleanup:
+      - '/bin'
       - '/include'
       - '/lib/pkgconfig'
       - '/lib/systemd'
@@ -53,6 +54,8 @@ modules:
 
   - name: elementary-stylesheet
     buildsystem: meson
+    cleanup:
+      - '/share/metainfo'
     sources:
       - type: archive
         url: https://github.com/elementary/stylesheet/archive/refs/tags/7.3.0.tar.gz
@@ -86,6 +89,11 @@ modules:
 
   - name: granite
     buildsystem: meson
+    config-opts:
+      - '-Ddemo=false'
+    cleanup:
+      - '/share/icons'
+      - '/share/metainfo'
     sources:
       - type: archive
         url: https://github.com/elementary/granite/archive/refs/tags/7.5.0.tar.gz

--- a/io.github.pantheon_tweaks.pantheon-tweaks.yml
+++ b/io.github.pantheon_tweaks.pantheon-tweaks.yml
@@ -99,6 +99,15 @@ modules:
         url: https://github.com/elementary/granite/archive/refs/tags/7.5.0.tar.gz
         sha256: 9439733169c07cfc658144ceef90bebac5f024ffda4bbb65e8c1ab68e5580908
 
+  - name: switchboard
+    buildsystem: meson
+    sources:
+      - type: archive
+        url: https://github.com/elementary/switchboard/archive/refs/tags/8.0.0.tar.gz
+        sha256: 99bf58f47b5cbdcfaf0415ff6ff5661fd4b18d779432884b6a62ef71f54be098
+      - type: patch
+        path: 0001-lib-Include-stylesheet-in-the-library.patch
+
   - name: pantheon-tweaks
     buildsystem: meson
     sources:

--- a/meson.build
+++ b/meson.build
@@ -53,6 +53,7 @@ executable(
         dependency('glib-2.0'),
         dependency('granite-7'),
         dependency('gtk4'),
+        dependency('switchboard-3'),
         meson.get_compiler('vala').find_library('posix')
     ],
     install: true

--- a/meson.build
+++ b/meson.build
@@ -53,7 +53,7 @@ executable(
         dependency('glib-2.0'),
         dependency('granite-7'),
         dependency('gtk4'),
-        dependency('switchboard-3'),
+        dependency('switchboard-3', version: '>= 8.0.0'),
         meson.get_compiler('vala').find_library('posix')
     ],
     install: true

--- a/src/Tweaks.vala
+++ b/src/Tweaks.vala
@@ -23,6 +23,18 @@ public class PantheonTweaks.Tweaks : Gtk.Application {
         settings = new Settings ("io.github.pantheon_tweaks.pantheon-tweaks");
     }
 
+    protected override void startup () {
+        base.startup ();
+
+        // Load stylesheet used in libswitchboard
+        unowned var display = Gdk.Display.get_default ();
+        var cssprovider = new Gtk.CssProvider ();
+        cssprovider.load_from_resource ("/io/elementary/settings/Application.css");
+        Gtk.StyleContext.add_provider_for_display (display,
+                cssprovider,
+                Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+    }
+
     protected override void activate () {
         if (window != null) {
             window.present ();

--- a/src/Widgets/Categories.vala
+++ b/src/Widgets/Categories.vala
@@ -38,7 +38,9 @@ public class PantheonTweaks.Categories : Gtk.Box {
             });
         }
 
-        var paned = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
+        var paned = new Gtk.Paned (Gtk.Orientation.HORIZONTAL) {
+            hexpand = true
+        };
         paned.resize_start_child = false;
         paned.shrink_start_child = false;
         paned.set_start_child (pane_list);
@@ -78,18 +80,19 @@ public class PantheonTweaks.Categories : Gtk.Box {
         });
     }
 
-    public abstract class Pane : Granite.SimpleSettingsPage {
+    public abstract class Pane : Switchboard.SettingsPage {
         public signal void restored ();
 
         protected delegate void Reset ();
 
         public PaneListItem pane_list_item { get; private set; }
+        protected Gtk.Grid content_area;
 
         protected Pane (string name, string title, string icon_name, string? description = null) {
             Object (
                 name: name,
                 title: title,
-                icon_name: icon_name,
+                icon: new ThemedIcon (icon_name),
                 description: description
             );
         }
@@ -97,9 +100,13 @@ public class PantheonTweaks.Categories : Gtk.Box {
         construct {
             pane_list_item = new PaneListItem (this);
 
-            content_area.vexpand = true;
-            content_area.hexpand = true;
-            content_area.margin_start = 60;
+            content_area = new Gtk.Grid () {
+                column_spacing = 12,
+                row_spacing = 12,
+                vexpand = true,
+                hexpand = true
+            };
+            child = content_area;
         }
 
         protected bool if_show_pane (string[] schemas) {
@@ -118,10 +125,9 @@ public class PantheonTweaks.Categories : Gtk.Box {
         }
 
         protected void on_click_reset (owned Reset reset_func) {
-            var reset = new Gtk.LinkButton (_("Reset to default"));
-            reset.can_focus = false;
+            var reset = add_button (_("Reset to default"));
 
-            reset.activate_link.connect (() => {
+            reset.clicked.connect (() => {
                 var reset_confirm_dialog = new Granite.MessageDialog.with_image_from_icon_name (
                     _("Are you sure you want to reset personalization?"),
                     _("All settings in this pane will be restored to the factory defaults. This action can't be undone."),
@@ -141,11 +147,7 @@ public class PantheonTweaks.Categories : Gtk.Box {
                     reset_confirm_dialog.destroy ();
                 });
                 reset_confirm_dialog.show ();
-
-                return true;
             });
-
-            action_area.append (reset);
         }
 
         protected class PaneListItem : Gtk.ListBoxRow {
@@ -162,7 +164,7 @@ public class PantheonTweaks.Categories : Gtk.Box {
                 label.hexpand = true;
                 label.halign = Gtk.Align.START;
 
-                var image = new Gtk.Image.from_icon_name (pane.icon_name) {
+                var image = new Gtk.Image.from_gicon (pane.icon) {
                     icon_size = Gtk.IconSize.LARGE
                 };
 


### PR DESCRIPTION
Granite.SimpleSettingsPage has been deprecated since Granite 7.5.0.

### Before
![スクリーンショット 2024-06-29 09 40 16](https://github.com/pantheon-tweaks/pantheon-tweaks/assets/26003928/5aaaf918-10dc-46c5-a9b2-b312d06ef8a4)

### After
![スクリーンショット 2024-06-29 09 39 55](https://github.com/pantheon-tweaks/pantheon-tweaks/assets/26003928/a3fd3a1d-e424-44c9-8b64-ba7b3a5773e1)
