### PR TITLE
FilesPane: Redesign

### DIFF
--- a/src/Panes/FilesPane.vala
+++ b/src/Panes/FilesPane.vala
@@ -18,21 +18,41 @@ public class PantheonTweaks.Panes.FilesPane : Categories.Pane {
 
         var settings = new GLib.Settings (FILES_SCHEMA);
 
-        var restore_tabs_label = summary_label_new (_("Restore tabs:"));
-        var restore_tabs_switch = switch_new ();
+        /*************************************************/
+        /* Restore Tabs                                  */
+        /*************************************************/
+        var restore_tabs_label = new Granite.HeaderLabel (_("Restore Tabs")) {
+            secondary_text = _("Restore tabs from previous session when launched"),
+            hexpand = true
+        };
+        var restore_tabs_switch = new Gtk.Switch () {
+            valign = Gtk.Align.START
+        };
+        var restore_tabs_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12);
+        restore_tabs_box.append (restore_tabs_label);
+        restore_tabs_box.append (restore_tabs_switch);
 
+        /*************************************************/
+        /* Date Format                                   */
+        /*************************************************/
         var date_format_map = new Gee.HashMap<string, string> ();
         date_format_map.set ("locale", _("Locale"));
         date_format_map.set ("iso", _("ISO"));
         date_format_map.set ("informal", _("Informal"));
 
-        var date_format_label = summary_label_new (_("Date format:"));
+        var date_format_label = new Granite.HeaderLabel (_("Date Format")) {
+            secondary_text = _("Date format used in the properties dialog or the list view"),
+            hexpand = true
+        };
         var date_format_combo = combobox_text_new (date_format_map);
+        date_format_combo.valign = Gtk.Align.START;
 
-        content_area.attach (restore_tabs_label, 0, 0, 1, 1);
-        content_area.attach (restore_tabs_switch, 1, 0, 1, 1);
-        content_area.attach (date_format_label, 0, 1, 1, 1);
-        content_area.attach (date_format_combo, 1, 1, 1, 1);
+        var date_format_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12);
+        date_format_box.append (date_format_label);
+        date_format_box.append (date_format_combo);
+
+        content_area.attach (restore_tabs_box, 0, 0, 1, 1);
+        content_area.attach (date_format_box, 0, 1, 1, 1);
 
         settings.bind ("restore-tabs", restore_tabs_switch, "active", SettingsBindFlags.DEFAULT);
         settings.bind ("date-format", date_format_combo, "active_id", SettingsBindFlags.DEFAULT);


### PR DESCRIPTION
- Add the description text using `Granite.HeaderLabel.secondary_text`
- Use Title Case for HeaderLabel
- Widget packing style in OS 8
- Leave block comment for legiblity