### PR TITLE
ThemeSettings: Split theme methods

### DIFF
--- a/src/Panes/AppearancePane.vala
+++ b/src/Panes/AppearancePane.vala
@@ -70,7 +70,7 @@ public class PantheonTweaks.Panes.AppearancePane : Categories.Pane {
             ),
             hexpand = true
         };
-        var gtk_list = ThemeSettings.get_themes ("themes", "gtk-3.0");
+        var gtk_list = ThemeSettings.fetch_gtk_themes ();
         gtk_combobox = combobox_text_new_from_list (gtk_list);
 
         var gtk_dir_button = new DestinationButton (".local/share/themes");
@@ -90,7 +90,7 @@ public class PantheonTweaks.Panes.AppearancePane : Categories.Pane {
             ),
             hexpand = true
         };
-        var icon_list = ThemeSettings.get_themes ("icons", "index.theme");
+        var icon_list = ThemeSettings.fetch_icon_themes ();
         var icon_combobox = combobox_text_new_from_list (icon_list);
 
         var icon_dir_button = new DestinationButton (".icons");
@@ -110,7 +110,7 @@ public class PantheonTweaks.Panes.AppearancePane : Categories.Pane {
             ),
             hexpand = true
         };
-        var cursor_list = ThemeSettings.get_themes ("icons", "cursors");
+        var cursor_list = ThemeSettings.fetch_cursor_themes ();
         var cursor_combobox = combobox_text_new_from_list (cursor_list);
 
         var cursor_dir_button = new DestinationButton (".icons");
@@ -130,7 +130,7 @@ public class PantheonTweaks.Panes.AppearancePane : Categories.Pane {
             ),
             hexpand = true
         };
-        var sound_list = ThemeSettings.get_themes ("sounds", "index.theme");
+        var sound_list = ThemeSettings.fetch_sound_themes ();
         var sound_combobox = combobox_text_new_from_list (sound_list);
 
         var sound_dir_button = new DestinationButton (".local/share/sounds");

--- a/src/Settings/ThemeSettings.vala
+++ b/src/Settings/ThemeSettings.vala
@@ -59,7 +59,23 @@ public class PantheonTweaks.ThemeSettings {
         "Adwaita", "Emacs", "Default", "default", "gnome", "hicolor"
     };
 
-    public static Gee.ArrayList<string>? get_themes (string path, string condition) {
+    public static Gee.ArrayList<string>? fetch_gtk_themes () {
+        return fetch_themes ("themes", "gtk-3.0");
+    }
+
+    public static Gee.ArrayList<string>? fetch_icon_themes () {
+        return fetch_themes ("icons", "index.theme");
+    }
+
+    public static Gee.ArrayList<string>? fetch_cursor_themes () {
+        return fetch_themes ("icons", "cursors");
+    }
+
+    public static Gee.ArrayList<string>? fetch_sound_themes () {
+        return fetch_themes ("sounds", "index.theme");
+    }
+
+    private static Gee.ArrayList<string>? fetch_themes (string path, string condition) {
         var themes = new Gee.ArrayList<string> ();
 
         string system_dir = "/usr/share/" + path + "/";


### PR DESCRIPTION
Wrap methods that have magic parameters. Also rename get_themes to fetch_themes because this is not a getter method.