### PR TITLE
Set font-weight as bold

### DIFF
--- a/data/styles/SettingsPage.scss
+++ b/data/styles/SettingsPage.scss
@@ -54,7 +54,8 @@ settingspage {
         }
 
         label.title-2 {
-            font-weight: 600;
+            // Cannot be a number or fonts break in Flatpak
+            font-weight: bold;
             font-size: 2rem;
         }
 

--- a/data/styles/SettingsSidebar.scss
+++ b/data/styles/SettingsSidebar.scss
@@ -52,7 +52,8 @@ settingssidebar {
 
                 box.start > label {
                     margin: rem(6px);
-                    font-weight: 500;
+                    // Cannot be a number or fonts break in Flatpak
+                    font-weight: bold;
                 }
 
                 box.end > switch {


### PR DESCRIPTION
Do not use a number for font-weight, otherwise serif font is used for these labels where sans-serif is expected.

Same fix with https://github.com/elementary/stylesheet/commit/a0af9bde6bba63b4b8850b042bbd8ee4a48f57ab and https://github.com/elementary/stylesheet/commit/df37637701b784a197dec6f5901f2e69fe45ed49

## Before
![スクリーンショット 2024-08-01 22 17 33](https://github.com/user-attachments/assets/ddafedad-c789-48d6-8899-4a11fe5e80f2)

## After
![スクリーンショット 2024-08-01 22 17 21](https://github.com/user-attachments/assets/8462ca10-fd61-448d-8e2a-1d017c6e74dd)
