### PR TITLE
Provide system theme rootdir as a build option

### DIFF
--- a/io.github.pantheon_tweaks.pantheon-tweaks.yml
+++ b/io.github.pantheon_tweaks.pantheon-tweaks.yml
@@ -14,8 +14,6 @@ finish-args:
   - '--filesystem=~/.icons:create'
   - '--filesystem=~/.local/share/sounds:create'
   - '--filesystem=~/.local/share/themes:create'
-  # Pass the directory where the host's /usr is mounted under, so that we can load system theme files
-  - '--env=USR_DIR_PREFIX=/var/run/host'
 
   # Needed to read/write GSettings of the host
   - '--talk-name=ca.desrt.dconf'
@@ -115,6 +113,9 @@ modules:
 
   - name: pantheon-tweaks
     buildsystem: meson
+    config-opts:
+      # Pass the directory where the host's /usr/share is mounted, so that we can load system theme files
+      - '-Dsystheme_rootdir=/var/run/host/usr/share'
     sources:
       - type: dir
         path: .

--- a/meson.build
+++ b/meson.build
@@ -17,9 +17,15 @@ add_global_arguments(
     language:'c'
 )
 
+systheme_rootdir = get_option('systheme_rootdir')
+if (systheme_rootdir == '')
+    systheme_rootdir = get_option('prefix') / get_option('datadir')
+endif
+
 config_data = configuration_data()
 config_data.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))
 config_data.set_quoted('GETTEXT_PACKAGE', gettext_name)
+config_data.set_quoted('SYSTHEME_ROOTDIR', systheme_rootdir)
 config_file = configure_file(
     input: 'src/Config.vala.in',
     output: '@BASENAME@',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('systheme_rootdir', type: 'string', description: 'Root directory where contains system themes')

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,2 +1,3 @@
 public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
 public const string LOCALEDIR = @LOCALEDIR@;
+public const string SYSTHEME_ROOTDIR = @SYSTHEME_ROOTDIR@;

--- a/src/Settings/ThemeSettings.vala
+++ b/src/Settings/ThemeSettings.vala
@@ -79,7 +79,7 @@ public class PantheonTweaks.ThemeSettings {
         var themes = new Gee.ArrayList<string> ();
 
         string[] dirs = {
-            Config.SYSTHEME_ROOTDIR + path + "/",
+            SYSTHEME_ROOTDIR + "/" + path + "/",
             Environment.get_home_dir () + "/." + path + "/",
             Environment.get_home_dir () + "/.local/share/" + path + "/"};
 

--- a/src/Settings/ThemeSettings.vala
+++ b/src/Settings/ThemeSettings.vala
@@ -78,14 +78,8 @@ public class PantheonTweaks.ThemeSettings {
     private static Gee.ArrayList<string>? fetch_themes (string path, string condition) {
         var themes = new Gee.ArrayList<string> ();
 
-        string system_dir = "/usr/share/" + path + "/";
-        string prefix = Environment.get_variable ("USR_DIR_PREFIX");
-        if (prefix != null) {
-            system_dir = prefix + system_dir;
-        }
-
         string[] dirs = {
-            system_dir,
+            Config.SYSTHEME_ROOTDIR + path + "/",
             Environment.get_home_dir () + "/." + path + "/",
             Environment.get_home_dir () + "/.local/share/" + path + "/"};
 


### PR DESCRIPTION
Reasons:

- It wouldn't happen that the root directory of system themes changes every time when the app launches, so it should be fine that being a build option instead of a runtime environment variable.
- This directory is completely different, which means it won't work just adding a prefix to `/usr/share/`, on some environments like NixOS. NixOS seems to [patch the source](https://github.com/NixOS/nixpkgs/blob/465eab85d222e5d52d46987edfb6f84b7c7723ed/pkgs/by-name/pa/pantheon-tweaks/package.nix#L48-L51) to refer correct directory. So allow packagers to set an arbitrary path instead of `/usr/share/`.