### PR TITLE
Flatpak: Use id instead of deprecated app-id

### DIFF
--- a/io.github.pantheon_tweaks.pantheon-tweaks.yml
+++ b/io.github.pantheon_tweaks.pantheon-tweaks.yml
@@ -1,4 +1,4 @@
-app-id: io.github.pantheon_tweaks.pantheon-tweaks
+id: io.github.pantheon_tweaks.pantheon-tweaks
 # elementary SDK is not available on Flathub, so use GNOME SDK and install elementary stylesheet and granite as modules
 runtime: org.gnome.Platform
 runtime-version: '47'


### PR DESCRIPTION
From https://docs.flatpak.org/en/latest/flatpak-builder-command-reference.html:

> Note, "app-id" is deprecated and preserved only for backwards compatibility.