### PR TITLE
Fix build failing when building switchboard

### DIFF
--- a/io.github.pantheon_tweaks.pantheon-tweaks.yml
+++ b/io.github.pantheon_tweaks.pantheon-tweaks.yml
@@ -29,6 +29,8 @@ finish-args:
 
   # Needed for PrefersAccentColor
   - --system-talk-name=org.freedesktop.Accounts
+build-options:
+  libdir: /app/lib
 modules:
   # Patch dconf to read/write GSettings of the host
   - name: dconf


### PR DESCRIPTION
It looks like granite-7 is installed into /app/lib64 where pkg-config doesn't search for