### PR TITLE
Redesign to square icon

### DIFF
--- a/data/icons/pantheon-tweaks.svg
+++ b/data/icons/pantheon-tweaks.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   version="1.0"
-   width="128.00006"
-   height="128.00006"
-   id="svg2453"
-   sodipodi:docname="128.svg"
+   id="svg4379"
+   height="128"
+   width="128"
+   version="1.1"
+   sodipodi:docname="pantheon-tweaks.svg"
    inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -23,24 +23,24 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1850"
-     inkscape:window-height="1011"
-     id="namedview123"
+     inkscape:window-width="1920"
+     inkscape:window-height="1018"
+     id="namedview46"
      showgrid="true"
-     inkscape:zoom="5.6568542"
-     inkscape:cx="52.237513"
-     inkscape:cy="64.081552"
+     inkscape:zoom="4"
+     inkscape:cx="48.5"
+     inkscape:cy="62.125"
      inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg2453"
+     inkscape:window-y="30"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4379"
      inkscape:document-rotation="0"
-     inkscape:showpageshadow="2"
+     inkscape:showpageshadow="0"
      inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1">
+     inkscape:deskcolor="#505050">
     <inkscape:grid
        type="xygrid"
-       id="grid1131"
+       id="grid865"
        empspacing="4"
        originx="0"
        originy="0"
@@ -50,131 +50,104 @@
        visible="true" />
     <inkscape:grid
        type="xygrid"
-       id="grid1133"
+       id="grid867"
        empspacing="2"
-       dotted="true"
        spacingy="0.5"
        spacingx="0.5"
-       color="#403fff"
-       opacity="0.2745098"
-       empcolor="#3f3fff"
-       empopacity="0.2745098"
+       dotted="true"
        originx="0"
        originy="0"
        units="px"
        visible="true" />
   </sodipodi:namedview>
-  <metadata
-     id="metadata35">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <defs
-     id="defs2455">
+     id="defs4381">
     <linearGradient
-       id="linearGradient1153">
+       id="linearGradient16"
+       inkscape:collect="always">
       <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
          offset="0"
-         style="stop-color:#90dbec;stop-opacity:1;"
-         id="stop1149" />
+         id="stop16" />
       <stop
-         offset="0.25999999"
-         style="stop-color:#55c1ec;stop-opacity:1;"
-         id="stop1" />
-      <stop
-         offset="0.69999999"
-         style="stop-color:#3689e6;stop-opacity:1;"
-         id="stop2" />
-      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
          offset="1"
-         style="stop-color:#2b63a0;stop-opacity:1;"
-         id="stop1151" />
+         id="stop17" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3462">
+       id="linearGradient7">
       <stop
-         id="stop3464"
-         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop6"
+         style="stop-color:#000000;stop-opacity:1;"
          offset="0" />
       <stop
-         id="stop3466"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.03457849" />
-      <stop
-         id="stop3468"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.96375686" />
-      <stop
-         id="stop3470"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop7"
+         style="stop-color:#000000;stop-opacity:1;"
          offset="1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3462"
-       id="linearGradient3133"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(3.1081078,0,0,2.4594594,36.290198,11.973044)"
-       x1="8.915328"
-       y1="5.2966995"
-       x2="8.915328"
-       y2="42.703293" />
-    <linearGradient
-       id="linearGradient3811">
+       id="linearGradient4">
       <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop3813" />
+         id="stop3"
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0" />
       <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop3815" />
+         id="stop4"
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3702-501-757-0">
+       id="linearGradient880">
       <stop
+         style="stop-color:#90dbec;stop-opacity:1;"
          offset="0"
-         style="stop-color:#181818;stop-opacity:0"
-         id="stop2895-0" />
+         id="stop876" />
       <stop
-         offset="0.5"
-         style="stop-color:#181818;stop-opacity:1"
-         id="stop2897-2" />
+         style="stop-color:#55c1ec;stop-opacity:1;"
+         offset="0.26163715"
+         id="stop1" />
       <stop
+         style="stop-color:#3689e6;stop-opacity:1;"
+         offset="0.69999999"
+         id="stop2" />
+      <stop
+         style="stop-color:#2b63a0;stop-opacity:1;"
          offset="1"
-         style="stop-color:#181818;stop-opacity:0"
-         id="stop2899-6" />
+         id="stop878" />
     </linearGradient>
     <linearGradient
+       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135124,1.486514)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3702-501-757-0"
-       id="linearGradient4097"
-       y2="39.999443"
-       x2="25.058096"
-       y1="47.027729"
-       x1="25.058096" />
+       xlink:href="#linearGradient3924-776"
+       id="linearGradient3159"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999" />
     <linearGradient
-       id="linearGradient3688-464-309-8">
+       id="linearGradient3924-776">
       <stop
          offset="0"
-         style="stop-color:#181818;stop-opacity:1"
-         id="stop2889-9" />
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3124" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3126" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3128" />
       <stop
          offset="1"
-         style="stop-color:#181818;stop-opacity:0"
-         id="stop2891-4" />
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3130" />
     </linearGradient>
     <radialGradient
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3688-464-309-8"
-       id="radialGradient4095"
+       xlink:href="#linearGradient3688-166-749-5"
+       id="radialGradient2455-1"
        fy="43.5"
        fx="4.9929786"
        r="2.5"
@@ -192,92 +165,87 @@
          id="stop2885-5" />
     </linearGradient>
     <radialGradient
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3688-166-749-5"
-       id="radialGradient4093"
+       xlink:href="#linearGradient3688-464-309-8"
+       id="radialGradient2457-5"
        fy="43.5"
        fx="4.9929786"
        r="2.5"
        cy="43.5"
        cx="4.9929786" />
-    <radialGradient
-       xlink:href="#linearGradient3811"
-       id="radialGradient5448"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7403296,0,0,0.16978827,71.011392,101.13029)"
-       cx="-4.0287771"
-       cy="93.467628"
-       fx="-4.0287771"
-       fy="93.467628"
-       r="35.338131" />
-    <radialGradient
-       cx="6.7304144"
-       cy="9.9571075"
-       r="12.671875"
-       fx="6.2001843"
-       fy="9.9571075"
-       id="radialGradient3395"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,25.083279,-30.794253,0,360.31658,-223.5918)" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
+       id="linearGradient3688-464-309-8">
       <stop
-         id="stop3750-1-0-7-6-6-1-3-9-3"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-9" />
       <stop
-         id="stop3756-1-6-2-6-6-1-96-6-0"
-         style="stop-color:#abacae;stop-opacity:1"
-         offset="1" />
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-4" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1153"
-       id="linearGradient1147"
-       x1="64"
-       y1="24.500061"
-       x2="64"
-       y2="117.50006"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-0"
+       id="linearGradient2459-7"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757-0">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-0" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-2" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3811">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop3813" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop3815" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.5563924,0,0,0.16978827,70.270358,102.13029)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3811"
+       id="radialGradient4377"
+       fy="93.467628"
+       fx="-4.0287771"
+       r="35.338131"
+       cy="93.467628"
+       cx="-4.0287771" />
+    <linearGradient
+       xlink:href="#linearGradient880"
+       id="linearGradient882"
+       x1="62.871635"
+       y1="15.90732"
+       x2="62.871635"
+       y2="118.42699"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient3965"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7297298,0,0,2.7297298,-14.513506,-14.513489)"
-       x1="23.99999"
-       y1="14.475261"
-       x2="23.99999"
-       y2="48.17823" />
-    <linearGradient
-       id="linearGradient3924">
-      <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3928"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.06316455" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615"
-       id="linearGradient3282"
+       x1="31"
+       y1="12.875"
+       x2="3.2591991"
+       y2="24.893845"
+       id="linearGradient3335"
        xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.5183614,0,0,3.2697194,3.4415505,6.322735)" />
+       gradientTransform="matrix(1.3290043,0,0,1.3290043,54.47403,5.1196883)" />
     <linearGradient
        id="linearGradient8265-821-176-38-919-66-249-7-7">
       <stop
@@ -289,15 +257,6 @@
          style="stop-color:#ffffff;stop-opacity:0"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       x1="31"
-       y1="12.875"
-       x2="3.2591991"
-       y2="24.893845"
-       id="linearGradient3335"
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3290043,0,0,1.3290043,54.47403,5.1196883)" />
     <radialGradient
        cx="32.5"
        cy="16.5625"
@@ -307,7 +266,7 @@
        id="radialGradient3337"
        xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8850237,0,0,0.8850237,68.903398,4.3329682)" />
+       gradientTransform="matrix(0.8850237,0,0,0.8850237,68.903398,2.9032641)" />
     <linearGradient
        x1="39"
        y1="26.125"
@@ -376,16 +335,55 @@
          style="stop-color:#eeeeec;stop-opacity:1"
          offset="1" />
     </linearGradient>
+    <linearGradient
+       x1="16.626165"
+       y1="15.298182"
+       x2="20.054544"
+       y2="24.627615"
+       id="linearGradient3282"
+       xlink:href="#linearGradient4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2503991,0,0,3.2950159,10.43022,-3.4353812)" />
+    <linearGradient
+       x1="16.626165"
+       y1="15.298182"
+       x2="20.054544"
+       y2="24.627615"
+       id="linearGradient3282-5"
+       xlink:href="#linearGradient7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.24443,0,0,4.2727377,10.032225,-9.1232878)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient16"
+       id="linearGradient17"
+       x1="48.536266"
+       y1="51.537361"
+       x2="57.549942"
+       y2="81.371574"
+       gradientUnits="userSpaceOnUse" />
   </defs>
+  <metadata
+     id="metadata4384">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="M 119,118 A 55,6 0 0 1 9.0000016,118 55,6 0 1 1 119,118 Z"
+     id="path3041"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient4377);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
   <g
-     id="g1145">
-    <path
-       inkscape:connector-curvature="0"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient5448);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-       id="path3041"
-       d="M 125.5,117 A 61.500002,6.0000004 0 0 1 2.4999976,117 61.500002,6.0000004 0 1 1 125.5,117 Z" />
+     transform="matrix(2.6999989,0,0,0.55555607,-0.8000019,94.888882)"
+     id="g2036"
+     style="display:inline">
     <g
-       transform="matrix(3.1842105,0,0,0.71428566,-12.421053,86.428574)"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
        id="g3712"
        style="opacity:0.4">
       <rect
@@ -393,59 +391,58 @@
          height="7"
          x="38"
          y="40"
-         id="rect2801-5"
-         style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none" />
+         id="rect2801"
+         style="fill:url(#radialGradient2455-1);fill-opacity:1;stroke:none" />
       <rect
          width="5"
          height="7"
          x="-10"
          y="-47"
          transform="scale(-1)"
-         id="rect3696-7"
-         style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none" />
+         id="rect3696"
+         style="fill:url(#radialGradient2457-5);fill-opacity:1;stroke:none" />
       <rect
          width="28"
          height="7.0000005"
          x="10"
          y="40"
-         id="rect3700-7"
-         style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none" />
+         id="rect3700"
+         style="fill:url(#linearGradient2459-7);fill-opacity:1;stroke:none" />
     </g>
   </g>
   <rect
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1147);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="rect4212"
-     width="117.00003"
-     height="93"
-     x="5.5"
-     y="24.500061"
+     width="103"
+     height="103"
      rx="10"
-     ry="10" />
-  <rect
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3965);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="rect4231"
-     width="115"
-     height="91"
-     x="6.5000305"
-     y="25.500061"
-     rx="9"
-     ry="9" />
-  <rect
      ry="10"
+     x="12.5"
+     y="15.5"
+     id="rect5505-21-3"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient882);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="101"
+     height="101"
+     rx="9"
+     ry="9"
+     x="13.5"
+     y="16.5"
+     id="rect6741-7"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3159);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     width="103"
+     height="103"
      rx="10"
-     y="24.500061"
-     x="5.5000305"
-     height="93.099998"
-     width="117"
-     id="rect4202"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#185f9a;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     ry="10"
+     x="12.500001"
+     y="15.5"
+     id="rect5505-21-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#185f9a;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="m 16.485691,25.000061 c -10.4864005,0 -10.4856605,8.336886 -10.4856605,10.567068 l 0.0386,49.739754 C 9.3756505,85.246143 119.46713,63.076507 122.00003,62.010129 V 35.515927 c 0,-1.70468 0.009,-10.515866 -10.51122,-10.515866 z"
-     id="path3333"
-     style="opacity:0.2;fill:url(#linearGradient3282);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.0812"
-     sodipodi:nodetypes="scccsss" />
+     id="rect1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient17);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;opacity:0.2"
+     d="M 22.5 15.5 C 16.960006 15.5 12.5 19.960006 12.5 25.5 L 12.5 79.691406 L 115.5 60.091797 L 115.5 25.5 C 115.5 19.960006 111.03999 15.5 105.5 15.5 L 22.5 15.5 z " />
   <g
-     transform="matrix(1.4228137,0,0,1.4228137,-58.184097,25.164319)"
+     transform="matrix(1.4228137,0,0,1.4228137,-58.184126,21.114258)"
      id="g3219">
     <path
        d="M 54.972406,34.690036 C 91.176595,36.98596 68.360516,16.085393 96.337662,15.419474 l 7.029388,14.771935 C 90.600018,24.238385 81.867039,54.82184 54.806281,36.849668 Z"
@@ -453,7 +450,7 @@
        style="display:inline;opacity:0.444444;fill:url(#linearGradient3335);fill-opacity:1;fill-rule:evenodd;stroke:none"
        inkscape:connector-curvature="0" />
     <path
-       d="m 110.4442,18.991174 c 0,7.056835 -5.7207,12.77753 -12.777532,12.77753 -7.056834,0 -12.777529,-5.720695 -12.777529,-12.77753 0,-7.056835 5.720695,-12.7775304 12.777529,-12.7775304 7.056832,0 12.777532,5.7206954 12.777532,12.7775304 z"
+       d="m 110.4442,17.56147 c 0,7.056835 -5.7207,12.77753 -12.777532,12.77753 -7.056834,0 -12.777529,-5.720695 -12.777529,-12.77753 0,-7.056835 5.720695,-12.7775305 12.777529,-12.7775305 7.056832,0 12.777532,5.7206955 12.777532,12.7775305 z"
        id="path3249"
        style="display:inline;fill:url(#radialGradient3337);fill-opacity:1;stroke:none"
        inkscape:connector-curvature="0" />


### PR DESCRIPTION
Official apps on Pantheon commonly uses icons in a square shape, so make sure that our icons looks good alongside them.

## After
![スクリーンショット 2024-12-31 11 24 46](https://github.com/user-attachments/assets/1105d66b-73f4-44e6-9484-db1c54c5e2ec)

## Before
![スクリーンショット 2024-12-31 11 25 42](https://github.com/user-attachments/assets/7614cfc9-eb3e-46a2-9716-fc075f75c148)
