### PR TITLE
Actions: Update flatpak-builder from v6 to v6.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           platforms: arm64
 
       - name: Build
-        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6.4
         with:
           bundle: pantheon-tweaks.flatpak
           manifest-path: io.github.pantheon_tweaks.pantheon-tweaks.yml


### PR DESCRIPTION
This fixes the CI failing with `Error: Create Artifact Container failed: The artifact name is not valid` error.
