### PR TITLE
chore: metainfo: Enable dark screenshot

### DIFF
--- a/data/pantheon-tweaks.metainfo.xml.in.in
+++ b/data/pantheon-tweaks.metainfo.xml.in.in
@@ -194,16 +194,13 @@
   </releases>
   <screenshots>
     <screenshot type="default" environment="pantheon">
-      <caption>Appearance pane</caption>
+      <caption>Appearance pane in the light mode</caption>
       <image>https://raw.githubusercontent.com/pantheon-tweaks/pantheon-tweaks/@VERSION@/data/screenshot.png</image>
     </screenshot>
-    <!-- TODO Uncomment when the supported AppStream is released. This causes linter error on Flathub at the moment. -->
-    <!--
     <screenshot environment="pantheon:dark">
-      <caption>Appearance pane</caption>
+      <caption>Appearance pane in the dark mode</caption>
       <image>https://raw.githubusercontent.com/pantheon-tweaks/pantheon-tweaks/@VERSION@/data/screenshot-dark.png</image>
     </screenshot>
-    -->
   </screenshots>
   <content_rating type="oars-1.1" />
   <!-- developer_name has deprecated since AppStream 1.0 -->


### PR DESCRIPTION
Support for `pantheon:dark` is added in AppStream 1.0.4:

https://github.com/ximion/appstream/commit/42a5e66dced26ce0871210acb4d75e4a14785f3a

And flatpak-builder comes with AppStream 1.0.4:

```
user@elementary-8-daily:~/work/pantheon-tweaks$ flatpak run --command=sh org.flatpak.Builder
sh: __bp_precmd_invoke_cmd: command not found
sh: __bp_interactive_mode: command not found
[📦 org.flatpak.Builder pantheon-tweaks]$ appstreamcli --version
AppStream version: 1.0.4
sh: __bp_precmd_invoke_cmd: command not found
sh: __bp_interactive_mode: command not found
[📦 org.flatpak.Builder pantheon-tweaks]$
```

So, using this environment style should no longer cause screenshot-invalid-env-style warning and linter error.
