### PR TITLE
chore: Flatpak: Remove sassc

### DIFF
--- a/io.github.pantheon_tweaks.pantheon-tweaks.yml
+++ b/io.github.pantheon_tweaks.pantheon-tweaks.yml
@@ -62,32 +62,6 @@ modules:
       - type: patch
         path: dconf-override.patch
 
-  - name: sassc
-    cleanup:
-      - '*'
-    buildsystem: autotools
-    sources:
-      - type: archive
-        url: https://github.com/sass/sassc/archive/refs/tags/3.6.2.tar.gz
-        sha256: 608dc9002b45a91d11ed59e352469ecc05e4f58fc1259fc9a9f5b8f0f8348a03
-      - type: script
-        dest-filename: autogen.sh
-        commands:
-          - autoreconf -si
-    modules:
-      - name: libsass
-        cleanup:
-          - '*'
-        buildsystem: autotools
-        sources:
-          - type: archive
-            url: https://github.com/sass/libsass/archive/refs/tags/3.6.5.tar.gz
-            sha256: 89d8f2c46ae2b1b826b58ce7dde966a176bac41975b82e84ad46b01a55080582
-          - type: script
-            dest-filename: autogen.sh
-            commands:
-              - autoreconf -si
-
   # TODO Remove when https://github.com/flathub/io.elementary.BaseApp/pull/30 is merged
   - name: granite
     buildsystem: meson


### PR DESCRIPTION
It's now included in latest version of the baseapp:

https://github.com/flathub/io.elementary.BaseApp/commit/efbeaf3fcbd8ebc6010bedd0c702f0e663b0b049
