### PR TITLE
bugfix: ThemeSettings: Correct position to insert menu

### DIFF
--- a/src/Settings/XSettings.vala
+++ b/src/Settings/XSettings.vala
@@ -50,8 +50,8 @@ public class PantheonTweaks.XSettings {
                 decoration_layout = new_layout + "menu";
             } else {
                 if (new_layout.contains (":")) {
-                    // e.g. "close:maximize" → "close:maximize,menu"
-                    decoration_layout = new_layout + ",menu";
+                    // e.g. "close:maximize" → "close:menu,maximize"
+                    decoration_layout = new_layout.replace (":", ":menu,");
                 } else {
                     // e.g. "close,minimize,maximize" → "close,minimize,maximize:menu"
                     decoration_layout = new_layout + ":menu";


### PR DESCRIPTION
This fixes the issue that choosing another window control layout then backing to elementary results different window layout; `close:maximize,menu`, not the default `close:menu,maximize`.
