### PR TITLE
chore: Fix some build warnings

### DIFF
--- a/src/Panes/FontsPane.vala
+++ b/src/Panes/FontsPane.vala
@@ -80,14 +80,33 @@ public class PantheonTweaks.Panes.FontsPane : BasePane {
         content_area.attach (mono_font_box, 0, 2, 1, 1);
         content_area.attach (titlebar_font_box, 0, 3, 1, 1);
 
-        interface_settings.bind_with_mapping ("font-name", default_font_button, "font-desc", SettingsBindFlags.DEFAULT,
-                font_button_bind_get, font_button_bind_set, null, null);
-        interface_settings.bind_with_mapping ("document-font-name", document_font_button, "font-desc", SettingsBindFlags.DEFAULT,
-                font_button_bind_get, font_button_bind_set, null, null);
-        interface_settings.bind_with_mapping ("monospace-font-name", mono_font_button, "font-desc", SettingsBindFlags.DEFAULT,
-                font_button_bind_get, font_button_bind_set, null, null);
-        window_settings.bind_with_mapping ("titlebar-font", titlebar_font_button, "font-desc", SettingsBindFlags.DEFAULT,
-                font_button_bind_get, font_button_bind_set, null, null);
+        interface_settings.bind_with_mapping ("font-name",
+            default_font_button, "font-desc",
+            SettingsBindFlags.DEFAULT,
+            (SettingsBindGetMappingShared) font_button_bind_get,
+            (SettingsBindSetMappingShared) font_button_bind_set,
+            null, null);
+
+        interface_settings.bind_with_mapping ("document-font-name",
+            document_font_button, "font-desc",
+            SettingsBindFlags.DEFAULT,
+            (SettingsBindGetMappingShared) font_button_bind_get,
+            (SettingsBindSetMappingShared) font_button_bind_set,
+            null, null);
+
+        interface_settings.bind_with_mapping ("monospace-font-name",
+            mono_font_button, "font-desc",
+            SettingsBindFlags.DEFAULT,
+            (SettingsBindGetMappingShared) font_button_bind_get,
+            (SettingsBindSetMappingShared) font_button_bind_set,
+            null, null);
+
+        window_settings.bind_with_mapping ("titlebar-font",
+            titlebar_font_button, "font-desc",
+            SettingsBindFlags.DEFAULT,
+            (SettingsBindGetMappingShared) font_button_bind_get,
+            (SettingsBindSetMappingShared) font_button_bind_set,
+            null, null);
     }
 
     protected override void do_reset () {

--- a/src/Panes/TerminalPane.vala
+++ b/src/Panes/TerminalPane.vala
@@ -119,8 +119,13 @@ public class PantheonTweaks.Panes.TerminalPane : BasePane {
         settings.bind ("remember-tabs", rem_tabs_switch, "active", SettingsBindFlags.DEFAULT);
         settings.bind ("audible-bell", term_bell_switch, "active", SettingsBindFlags.DEFAULT);
         settings.bind ("tab-bar-behavior", tab_bar_combo, "active_id", SettingsBindFlags.DEFAULT);
-        settings.bind_with_mapping ("font", term_font_button, "font-desc", SettingsBindFlags.DEFAULT,
-                                    font_button_bind_get, font_button_bind_set, null, null);
+
+        settings.bind_with_mapping ("font",
+            term_font_button, "font-desc",
+            SettingsBindFlags.DEFAULT,
+            (SettingsBindGetMappingShared) font_button_bind_get,
+            (SettingsBindSetMappingShared) font_button_bind_set,
+            null, null);
     }
 
     protected override void do_reset () {

--- a/src/Widgets/BasePane.vala
+++ b/src/Widgets/BasePane.vala
@@ -71,7 +71,7 @@ public abstract class BasePane : Switchboard.SettingsPage {
             reset_confirm_dialog.destroy ();
             restored ();
         });
-        reset_confirm_dialog.show ();
+        reset_confirm_dialog.present ();
     }
 
     protected Gtk.ComboBoxText combobox_text_new (Gee.HashMap<string, string> items) {

--- a/src/Widgets/OpenButton.vala
+++ b/src/Widgets/OpenButton.vala
@@ -58,6 +58,6 @@ public class OpenButton : Gtk.Button {
         error_dialog.response.connect ((response_id) => {
             error_dialog.destroy ();
         });
-        error_dialog.show ();
+        error_dialog.present ();
     }
 }


### PR DESCRIPTION
- Use `Gtk.Widget.present ()` instead of [deprecated `Gtk.Widget.show ()`](https://docs.gtk.org/gtk4/method.Widget.show.html)
- Fix `-Wincompatible-pointer-types` warnings of `GLib.Settings.bind_with_mapping ()`
