### PR TITLE
chore: Use GLib.ApplicationFlags.DEFAULT_FLAGS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -59,7 +59,8 @@ executable(
     stylesheet_resource,
     dependencies: [
         dependency('gee-0.8'),
-        dependency('glib-2.0'),
+        # Version limitation for GLib.ApplicationFlags.DEFAULT_FLAGS
+        dependency('glib-2.0', version: '>= 2.74'),
         dependency('granite-7', version: '>= 7.1.0'),
         dependency('gtk4', version: '>= 4.10'),
         dependency('pango'),

--- a/src/Tweaks.vala
+++ b/src/Tweaks.vala
@@ -15,7 +15,7 @@ public class PantheonTweaks.Tweaks : Gtk.Application {
 
         Object (
             application_id: "io.github.pantheon_tweaks.pantheon-tweaks",
-            flags: ApplicationFlags.FLAGS_NONE
+            flags: ApplicationFlags.DEFAULT_FLAGS
         );
     }
 


### PR DESCRIPTION
[`GLib.ApplicationFlags.FLAGS_NONE`](https://valadoc.org/gio-2.0/GLib.ApplicationFlags.FLAGS_NONE.html) has been deprecated since 2.74.
