### PR TITLE
fix: Bump required granite-7 version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,7 +61,7 @@ executable(
         dependency('gee-0.8'),
         # Version limitation for GLib.ApplicationFlags.DEFAULT_FLAGS
         dependency('glib-2.0', version: '>= 2.74'),
-        # Version limitation for automati load of Application.css
+        # Version limitation for automatic load of Application.css
         dependency('granite-7', version: '>= 7.3.0'),
         # Version limitation for Gtk.FontDialogButton
         dependency('gtk4', version: '>= 4.10'),

--- a/meson.build
+++ b/meson.build
@@ -61,9 +61,12 @@ executable(
         dependency('gee-0.8'),
         # Version limitation for GLib.ApplicationFlags.DEFAULT_FLAGS
         dependency('glib-2.0', version: '>= 2.74'),
-        dependency('granite-7', version: '>= 7.1.0'),
+        # Version limitation for automati load of Application.css
+        dependency('granite-7', version: '>= 7.3.0'),
+        # Version limitation for Gtk.FontDialogButton
         dependency('gtk4', version: '>= 4.10'),
         dependency('pango'),
+        # Version limitation for GTK4 ported version
         dependency('switchboard-3', version: '>= 8.0.0'),
         meson.get_compiler('vala').find_library('posix')
     ],


### PR DESCRIPTION
We must require granite-7 >= 7.3.0 for the automatic load of Application.css:

https://github.com/elementary/granite/commit/2b6d52043cb1f8a30e54675f8c375f2712ad5c92

Also explicit reasons for each version limitation while I'm here.
