### PR TITLE
fix: Apply color scheme preference to app-wide

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -21,18 +21,6 @@ public class PantheonTweaks.MainWindow : Gtk.ApplicationWindow {
         };
 
         set_titlebar (headerbar);
-
-        // Follow OS-wide dark preference
-        var granite_settings = Granite.Settings.get_default ();
-        var gtk_settings = Gtk.Settings.get_default ();
-
-        granite_settings.bind_property ("prefers-color-scheme", gtk_settings, "gtk-application-prefer-dark-theme",
-            BindingFlags.DEFAULT | BindingFlags.SYNC_CREATE,
-            ((binding, granite_prop, ref gtk_prop) => {
-                gtk_prop.set_boolean ((Granite.Settings.ColorScheme) granite_prop == Granite.Settings.ColorScheme.DARK);
-                return true;
-            })
-        );
     }
 
     public void load () {

--- a/src/Tweaks.vala
+++ b/src/Tweaks.vala
@@ -27,6 +27,18 @@ public class PantheonTweaks.Tweaks : Gtk.Application {
         base.startup ();
 
         Granite.init ();
+
+        // Follow OS-wide dark preference
+        var granite_settings = Granite.Settings.get_default ();
+        var gtk_settings = Gtk.Settings.get_default ();
+
+        granite_settings.bind_property ("prefers-color-scheme", gtk_settings, "gtk-application-prefer-dark-theme",
+            BindingFlags.DEFAULT | BindingFlags.SYNC_CREATE,
+            ((binding, granite_prop, ref gtk_prop) => {
+                gtk_prop.set_boolean ((Granite.Settings.ColorScheme) granite_prop == Granite.Settings.ColorScheme.DARK);
+                return true;
+            })
+        );
     }
 
     protected override void activate () {


### PR DESCRIPTION
The previous code only applies color scheme preference to the main window and its followings. This change is meaningless in our code because we have no other windows but this makes more sense.
