### PR TITLE
chore: Generalize error dialogs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -54,6 +54,7 @@ source_files = files(
     'src/Util/StringListUtil.vala',
     'src/Widgets/BasePane.vala',
     'src/Widgets/Categories.vala',
+    'src/Widgets/Dialog.vala',
     'src/Widgets/DropDownId.vala',
     'src/Widgets/DropDownRow.vala',
     'src/Widgets/OpenButton.vala',

--- a/src/Widgets/Categories.vala
+++ b/src/Widgets/Categories.vala
@@ -5,8 +5,6 @@
  */
 
 public class PantheonTweaks.Categories : Gtk.Box {
-    private const string BUGTRACKER_URL = "https://github.com/pantheon-tweaks/pantheon-tweaks/issues";
-
     private Gtk.Stack stack;
     private Granite.Toast toast;
 
@@ -51,21 +49,10 @@ public class PantheonTweaks.Categories : Gtk.Box {
 
             bool ret = _pane.load ();
             if (!ret) {
-                var warning_dialog = new Granite.MessageDialog.with_image_from_icon_name (
+                Dialog.show_error_dialog (
                     _("Failed to Load %s Preference").printf (_pane.title),
-                    _("Make sure your Pantheon desktop installation is up to date and not incomplete. Please report this problem on our bugtracker if it persists."),
-                    "dialog-warning", Gtk.ButtonsType.CLOSE
-                ) {
-                    modal = true,
-                    transient_for = (Gtk.Window) get_root (),
-                };
-
-                var report_button = new Gtk.LinkButton.with_label (BUGTRACKER_URL, _("Report Problem…"));
-                warning_dialog.custom_bin.append (report_button);
-
-                warning_dialog.response.connect (warning_dialog.destroy);
-
-                warning_dialog.present ();
+                    _("Make sure your Pantheon desktop installation is up to date and not incomplete.")
+                );
 
                 continue;
             }

--- a/src/Widgets/Dialog.vala
+++ b/src/Widgets/Dialog.vala
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: elementary Tweaks Developers, 2014-2020
+ *                         Pantheon Tweaks Developers, 2020-2025
+ */
+
+namespace Dialog {
+    private const string HELP_URL = "https://github.com/pantheon-tweaks/pantheon-tweaks/discussions";
+
+    public void show_error_dialog (string title, string desc, string? details = null) {
+        var error_dialog = new Granite.MessageDialog.with_image_from_icon_name (
+            title, desc, "dialog-error", Gtk.ButtonsType.CLOSE
+        ) {
+            modal = true,
+            transient_for = ((Gtk.Application) GLib.Application.get_default ()).active_window
+        };
+
+        var help_button = new Gtk.LinkButton.with_label (HELP_URL, _("Get Support…"));
+        error_dialog.custom_bin.append (help_button);
+
+        if (details != null) {
+            error_dialog.show_error_details (details);
+        }
+
+        error_dialog.response.connect (error_dialog.destroy);
+
+        error_dialog.present ();
+    }
+}

--- a/src/Widgets/OpenButton.vala
+++ b/src/Widgets/OpenButton.vala
@@ -21,7 +21,7 @@ public class OpenButton : Gtk.Button {
             try {
                 open ();
             } catch (Error err) {
-                show_folder_action_error (
+                Dialog.show_error_dialog (
                     _("Failed To Open \"%s\"").printf (path),
                     _("Tried to open the folder but failed. The following error message might be helpful:"),
                     err.message
@@ -47,19 +47,5 @@ public class OpenButton : Gtk.Button {
             warning ("Failed to open '%s': %s", path, err.message);
             throw err;
         }
-    }
-
-    private void show_folder_action_error (string primary_text, string secondary_text, string error_message) {
-        var error_dialog = new Granite.MessageDialog.with_image_from_icon_name (
-            primary_text, secondary_text, "dialog-error", Gtk.ButtonsType.CLOSE
-        ) {
-            modal = true,
-            transient_for = (Gtk.Window) get_root ()
-        };
-        error_dialog.show_error_details (error_message);
-        error_dialog.response.connect ((response_id) => {
-            error_dialog.destroy ();
-        });
-        error_dialog.present ();
     }
 }

--- a/src/Widgets/OpenButton.vala
+++ b/src/Widgets/OpenButton.vala
@@ -23,7 +23,7 @@ public class OpenButton : Gtk.Button {
             } catch (Error err) {
                 Dialog.show_error_dialog (
                     _("Failed To Open \"%s\"").printf (path),
-                    _("Tried to open the folder but failed. The following error message might be helpful:"),
+                    _("There was an error when opening the directory or creating it."),
                     err.message
                 );
             }


### PR DESCRIPTION
Unify code between 2 error dialogs:

![image](https://github.com/user-attachments/assets/6f54c243-330c-42cd-916a-a10a37471e18)

![image](https://github.com/user-attachments/assets/06b1f794-d0ab-4506-8ab3-d1da105e4cdc)
