### PR TITLE
refactor: Replace Gtk.Grid with Gtk.Box

### DIFF
--- a/src/Panes/AppearancePane.vala
+++ b/src/Panes/AppearancePane.vala
@@ -203,13 +203,13 @@ public class PantheonTweaks.Panes.AppearancePane : BasePane {
         gnome_menu_switch_box.append (gnome_menu_switch_label);
         gnome_menu_switch_box.append (gnome_menu_switch);
 
-        content_area.attach (gtk_theme_box, 0, 0, 1, 1);
-        content_area.attach (icon_box, 0, 1, 1, 1);
-        content_area.attach (cursor_box, 0, 2, 1, 1);
-        content_area.attach (sound_box, 0, 3, 1, 1);
-        content_area.attach (dark_style_box, 0, 4, 1, 1);
-        content_area.attach (controls_box, 0, 5, 1, 1);
-        content_area.attach (gnome_menu_switch_box, 0, 6, 1, 1);
+        content_area.append (gtk_theme_box);
+        content_area.append (icon_box);
+        content_area.append (cursor_box);
+        content_area.append (sound_box);
+        content_area.append (dark_style_box);
+        content_area.append (controls_box);
+        content_area.append (gnome_menu_switch_box);
     }
 
     public override bool load () {

--- a/src/Panes/FilesPane.vala
+++ b/src/Panes/FilesPane.vala
@@ -51,8 +51,8 @@ public class PantheonTweaks.Panes.FilesPane : BasePane {
         date_format_box.append (date_format_label);
         date_format_box.append (date_format_dropdown);
 
-        content_area.attach (restore_tabs_box, 0, 0, 1, 1);
-        content_area.attach (date_format_box, 0, 1, 1, 1);
+        content_area.append (restore_tabs_box);
+        content_area.append (date_format_box);
     }
 
     public override bool load () {

--- a/src/Panes/FontsPane.vala
+++ b/src/Panes/FontsPane.vala
@@ -85,10 +85,10 @@ public class PantheonTweaks.Panes.FontsPane : BasePane {
         titlebar_font_box.append (titlebar_font_label);
         titlebar_font_box.append (titlebar_font_button);
 
-        content_area.attach (default_font_box, 0, 0, 1, 1);
-        content_area.attach (document_font_box, 0, 1, 1, 1);
-        content_area.attach (mono_font_box, 0, 2, 1, 1);
-        content_area.attach (titlebar_font_box, 0, 3, 1, 1);
+        content_area.append (default_font_box);
+        content_area.append (document_font_box);
+        content_area.append (mono_font_box);
+        content_area.append (titlebar_font_box);
     }
 
     public override bool load () {

--- a/src/Panes/MiscPane.vala
+++ b/src/Panes/MiscPane.vala
@@ -35,8 +35,8 @@ public class PantheonTweaks.Panes.MiscPane : BasePane {
         max_volume_box.append (max_volume_scale);
         max_volume_box.append (max_volume_spinbutton);
 
-        content_area.attach (indicator_sound_label, 0, 0, 1, 1);
-        content_area.attach (max_volume_box, 0, 1, 1, 1);
+        content_area.append (indicator_sound_label);
+        content_area.append (max_volume_box);
     }
 
     public override bool load () {

--- a/src/Panes/TerminalPane.vala
+++ b/src/Panes/TerminalPane.vala
@@ -118,12 +118,12 @@ public class PantheonTweaks.Panes.TerminalPane : BasePane {
         term_font_box.append (term_font_label);
         term_font_box.append (term_font_button);
 
-        content_area.attach (follow_last_tab_box, 0, 0, 1, 1);
-        content_area.attach (unsafe_paste_alert_box, 0, 1, 1, 1);
-        content_area.attach (rem_tabs_box, 0, 2, 1, 1);
-        content_area.attach (term_bell_box, 0, 3, 1, 1);
-        content_area.attach (tab_bar_box, 0, 4, 1, 1);
-        content_area.attach (term_font_box, 0, 5, 1, 1);
+        content_area.append (follow_last_tab_box);
+        content_area.append (unsafe_paste_alert_box);
+        content_area.append (rem_tabs_box);
+        content_area.append (term_bell_box);
+        content_area.append (tab_bar_box);
+        content_area.append (term_font_box);
     }
 
     public override bool load () {

--- a/src/Widgets/BasePane.vala
+++ b/src/Widgets/BasePane.vala
@@ -11,7 +11,7 @@ public abstract class BasePane : Switchboard.SettingsPage {
     protected abstract void do_reset ();
 
     protected bool is_load_success { get; protected set; }
-    protected Gtk.Grid content_area;
+    protected Gtk.Box content_area;
 
     protected BasePane (string name, string title, string icon_name, string? description = null) {
         Object (
@@ -27,9 +27,7 @@ public abstract class BasePane : Switchboard.SettingsPage {
 
         is_load_success = false;
 
-        content_area = new Gtk.Grid () {
-            column_spacing = 12,
-            row_spacing = 18,
+        content_area = new Gtk.Box (Gtk.Orientation.VERTICAL, 12) {
             vexpand = true,
             hexpand = true
         };


### PR DESCRIPTION
We attach each box into the content area, so it's meaningless that the content area is an Gtk.Grid.
