### PR TITLE
chore: meson: Remove posix dep

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -52,7 +52,6 @@ executable(
         dependency('pango'),
         # Version limitation for GTK4 ported version
         dependency('switchboard-3', version: '>= 8.0.0'),
-        meson.get_compiler('vala').find_library('posix')
     ],
     install: true
 )


### PR DESCRIPTION
This seems to be originally added to the meson.build in ceea22fd by me, I didn't remember though, but I don't feel it's not used in the source code at all then and now. Maybe I brought it to the meson.build since it was in the CMake files? Anyways I think we can safely remove it from the dependencies.

```
user@elementary-daily:~/work/pantheon-tweaks ((ceea22f...))$ git grepn -i posix
cmake/README.Vala.rst:121:        posix
cmake/ValaPrecompile.cmake:96:#       posix
meson.build:64:        meson.get_compiler('vala').find_library('posix'),
src/CMakeLists.txt:52:    posix
user@elementary-daily:~/work/pantheon-tweaks ((ceea22f...))$
```