### PR TITLE
chore: flatpak: Update elementary BaseApp to circe-25.08

### DIFF
--- a/build-aux/io.github.pantheon_tweaks.pantheon-tweaks.yml
+++ b/build-aux/io.github.pantheon_tweaks.pantheon-tweaks.yml
@@ -1,7 +1,7 @@
 id: io.github.pantheon_tweaks.pantheon-tweaks
 # elementary SDK is not available on Flathub, so use the elementary BaseApp instead
 base: io.elementary.BaseApp
-base-version: circe-24.08
+base-version: circe-25.08
 runtime: org.gnome.Platform
 runtime-version: '49'
 sdk: org.gnome.Sdk


### PR DESCRIPTION
Requires flathub/io.elementary.BaseApp#36
