### PR TITLE
feat: TerminalPane: Remove 'Never Show Tabs' option

### DIFF
--- a/src/Panes/TerminalPane.vala
+++ b/src/Panes/TerminalPane.vala
@@ -100,7 +100,6 @@ public class PantheonTweaks.Panes.TerminalPane : BasePane {
         tab_bar_list = new ListStore (typeof (StringIdObject));
         tab_bar_list.append (new StringIdObject ("Always Show Tabs", _("Always")));
         tab_bar_list.append (new StringIdObject ("Hide When Single Tab", _("Hide when single tab")));
-        tab_bar_list.append (new StringIdObject ("Never Show Tabs", _("Never")));
 
         tab_bar_dropdown = DropDownId.new (tab_bar_list);
 


### PR DESCRIPTION
Fixes #331

The tab behavior feature had been removed and the GSettings key was a leftover, but it came back in https://github.com/elementary/terminal/commit/4110ae4c6a4f4d4d24b7c0102f6c8d0f39a57762 without the "Never Show Tabs" option. This PR follows this change.
