### PR TITLE
fix: MainWindow: Add missing window title

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -15,6 +15,8 @@ public class PantheonTweaks.MainWindow : Gtk.ApplicationWindow {
     }
 
     construct {
+        title = _("Pantheon Tweaks");
+
         headerbar = new Gtk.HeaderBar () {
             show_title_buttons = true,
             title_widget = new Gtk.Label (_("Pantheon Tweaks"))


### PR DESCRIPTION
This fixes the window title fallbacks to the executable name in Multitasking View.

## Before
<img width="1720" height="1279" alt="スクリーンショット 2025-11-29 13 45 47" src="https://github.com/user-attachments/assets/7bb5ad5c-a777-4e19-a811-5cf40ec8afde" />

## After
<img width="1720" height="1279" alt="スクリーンショット 2025-11-29 13 44 32" src="https://github.com/user-attachments/assets/b802cf8f-2dc5-46cb-be8f-7f63fc7604fa" />
