### PR TITLE
feat: Dialog: Drop support URL

### DIFF
--- a/src/Widgets/Dialog.vala
+++ b/src/Widgets/Dialog.vala
@@ -5,8 +5,6 @@
  */
 
 namespace PantheonTweaks.Dialog {
-    private const string HELP_URL = "https://github.com/pantheon-tweaks/pantheon-tweaks/discussions";
-
     public void show_error_dialog (string title, string desc, string? details = null) {
         var error_dialog = new Granite.MessageDialog.with_image_from_icon_name (
             title, desc, "dialog-error", Gtk.ButtonsType.CLOSE
@@ -14,9 +12,6 @@ namespace PantheonTweaks.Dialog {
             modal = true,
             transient_for = ((Gtk.Application) GLib.Application.get_default ()).active_window
         };
-
-        var help_button = new Gtk.LinkButton.with_label (HELP_URL, _("Get Support…"));
-        error_dialog.custom_bin.append (help_button);
 
         if (details != null) {
             error_dialog.show_error_details (details);


### PR DESCRIPTION
Because this would not be an action user would take.