### PR TITLE
chore: Flatpak: Add sassc and libsass as modules

### DIFF
--- a/build-aux/io.github.pantheon_tweaks.pantheon-tweaks.yml
+++ b/build-aux/io.github.pantheon_tweaks.pantheon-tweaks.yml
@@ -81,6 +81,32 @@ modules:
           version-query: .tag_name
           url-query: '"https://github.com/elementary/settings/archive/" + .tag_name + ".tar.gz"'
           timestamp-query: .published_at
+    modules:
+      - name: sassc
+        cleanup:
+          - '*'
+        buildsystem: autotools
+        sources:
+          - type: archive
+            url: https://github.com/sass/sassc/archive/3.6.2.tar.gz
+            sha256: 608dc9002b45a91d11ed59e352469ecc05e4f58fc1259fc9a9f5b8f0f8348a03
+          - type: script
+            dest-filename: autogen.sh
+            commands:
+              - autoreconf -si
+        modules:
+          - name: libsass
+            cleanup:
+              - '*'
+            buildsystem: autotools
+            sources:
+              - type: archive
+                url: https://github.com/sass/libsass/archive/3.6.5.tar.gz
+                sha256: 89d8f2c46ae2b1b826b58ce7dde966a176bac41975b82e84ad46b01a55080582
+              - type: script
+                dest-filename: autogen.sh
+                commands:
+                  - autoreconf -si
 
   - name: pantheon-tweaks
     buildsystem: meson


### PR DESCRIPTION
Preparation for io.elementary.BaseApp circe-26.04 that will cleanup these modules from itself.

See also: https://github.com/flathub/io.elementary.BaseApp/pull/51
